### PR TITLE
[#bug] Rename boleto-api build reference in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 vendor/
-boletoapi
+boleto-api
 *.pid
 *.exe
 debug


### PR DESCRIPTION
Change log:
- Rename boleto-api build reference in .gitignore