### PR TITLE
Sanitize HTML Instructions

### DIFF
--- a/boleto/html.go
+++ b/boleto/html.go
@@ -322,7 +322,7 @@ const boletoForm = `
             <tr>
                 <td colspan="6" rowspan="4">
                     <span class="title">Instruções de responsabilidade do BENEFICIÁRIO. Qualquer dúvida sobre este boleto contate o beneficiário.</span>
-                    <p class="content" id="instructions">{{unescapeHtmlString .View.Boleto.Title.Instructions}}</p>
+                    <p class="content" id="instructions">{{unescapeHtmlString .View.Boleto.Title.Instructions }}</p>
                 </td>
             </tr>
             <tr>

--- a/tmpl/funcmaps.go
+++ b/tmpl/funcmaps.go
@@ -2,6 +2,7 @@ package tmpl
 
 import (
 	"bytes"
+	"html"
 	"html/template"
 	"strings"
 	"time"
@@ -9,8 +10,6 @@ import (
 	"strconv"
 
 	"fmt"
-
-	"html"
 
 	"github.com/kennygrant/sanitize"
 	"github.com/mundipagg/boleto-api/config"
@@ -89,8 +88,13 @@ func unscape(s string) template.HTML {
 	return template.HTML(s)
 }
 
+func sanitizeHtmlString(s string) string {
+	return sanitize.HTML(s)
+}
+
 func unescapeHtmlString(s string) template.HTML {
-	return template.HTML(html.UnescapeString(s))
+	str := sanitizeHtmlString(s)
+	return template.HTML(html.UnescapeString(str))
 }
 
 func trimLeft(s string, caract string) string {

--- a/tmpl/template_test.go
+++ b/tmpl/template_test.go
@@ -126,3 +126,17 @@ func TestTrim(t *testing.T) {
 		So(trim(d), ShouldEqual, "hue br festa")
 	})
 }
+
+func TestSanitizeHtml(t *testing.T) {
+	Convey("O texto não deve conter HTML tags", t, func() {
+		d := "<p>hu3 br festa</p>"
+		So(sanitizeHtmlString(d), ShouldEqual, "hu3 br festa")
+	})
+}
+
+func TestUnscapeHtml(t *testing.T) {
+	Convey("A string não deve ter caracteres Unicode", t, func() {
+		d := "N&amp;#195;O RECEBER AP&amp;#211;S O VENCIMENTO."
+		So(unescapeHtmlString(d), ShouldEqual, "NÃO RECEBER APÓS O VENCIMENTO.")
+	})
+}

--- a/tmpl/template_test.go
+++ b/tmpl/template_test.go
@@ -129,14 +129,14 @@ func TestTrim(t *testing.T) {
 
 func TestSanitizeHtml(t *testing.T) {
 	Convey("O texto não deve conter HTML tags", t, func() {
-		d := "<p>hu3 br festa</p>"
+		d := "<b>hu3 br festa</b>"
 		So(sanitizeHtmlString(d), ShouldEqual, "hu3 br festa")
 	})
 }
 
 func TestUnscapeHtml(t *testing.T) {
 	Convey("A string não deve ter caracteres Unicode", t, func() {
-		d := "N&amp;#195;O RECEBER AP&amp;#211;S O VENCIMENTO."
-		So(unescapeHtmlString(d), ShouldEqual, "NÃO RECEBER APÓS O VENCIMENTO.")
+		d := "&#243;"
+		So(unescapeHtmlString(d), ShouldEqual, "ó")
 	})
 }


### PR DESCRIPTION
**O que**
Limpa as tags HTML mandadas para as Instruções do boleto

**Por que**
Devido a casos que o HTML estava quebrando a renderização do boleto