### PR TITLE
Fix/add build flags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,10 @@ jobs:
   build:
     docker:
       - image: golang:1.8
+    environment:
+      - GOOS: "linux"
+      - GOARCH: "amd64"
+      - CGO_ENABLED: "0"
     
     working_directory: /go/src/github.com/mundipagg/boleto-api
 

--- a/devops/Dockerfile
+++ b/devops/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.7
 
 RUN mkdir -p "/home/mundipagg/"
 RUN mkdir -p "/home/mundipagg/boleto_ssh"


### PR DESCRIPTION
What?
Fixes application binaries being built incorrectly.
Change Docker image alpine version to 3.7.

How?
Add the correct build flags to CircleCI config.yml

Why?
The docker image is broken because of the wrong application binaries