### PR TITLE
fix environment variable expansion in curl command at deployment step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
                         "tag": "master"
                         },
                         "repository": {
-                        "repo_name": "${DOCKER_ACCOUNT}/${PROJECT_NAME}"
+                        "repo_name": "'"${DOCKER_ACCOUNT}/${PROJECT_NAME}"'"
                         }
               }'
             fi
@@ -73,7 +73,7 @@ jobs:
                         "tag": "develop"
                         },
                         "repository": {
-                        "repo_name": "${DOCKER_ACCOUNT}/${PROJECT_NAME}"
+                        "repo_name": "'"${DOCKER_ACCOUNT}/${PROJECT_NAME}"'"
                         }
               }'
             fi


### PR DESCRIPTION
What?
Fix environment variable expansion in curl command at deployment step

How?
Properly surrounding the environment variables in curl payload with double-quotes

Why?
The environment variables in curl command are not being expanded, causing the deployment to fail since the values are not being substituted 