### PR TITLE
:sparkles: Sanitize Cep

### DIFF
--- a/bradescoShopFacil/bradescoShopFacil_test.go
+++ b/bradescoShopFacil/bradescoShopFacil_test.go
@@ -41,7 +41,7 @@ const baseMockJSON = `
             "Street": "Mos Eisley Cantina",
             "Number": "123",
             "Complement": "Apto",
-            "ZipCode": "20001000",
+            "ZipCode": "20001-000",
             "City": "Tatooine",
             "District": "Tijuca",
             "StateCode": "RJ"

--- a/bradescoShopFacil/request.go
+++ b/bradescoShopFacil/request.go
@@ -15,7 +15,7 @@ const registerBradescoShopFacil = `
         "nome": "{{.Buyer.Name}}",
         "documento": "{{.Buyer.Document.Number}}",
         "endereco": {
-            "cep": "{{.Buyer.Address.ZipCode}}",
+            "cep": "{{extractNumbers .Buyer.Address.ZipCode}}",
             "logradouro": "{{.Buyer.Address.Street}}",
             "numero": "{{.Buyer.Address.Number}}",
             "complemento": "{{.Buyer.Address.Complement}}",

--- a/tmpl/funcmaps.go
+++ b/tmpl/funcmaps.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"html"
 	"html/template"
+	"regexp"
 	"strings"
 	"time"
 
@@ -54,6 +55,7 @@ var funcMap = template.FuncMap{
 	"mod10dv":                mod10Itau,
 	"printIfNotProduction":   printIfNotProduction,
 	"itauEnv":                itauEnv,
+	"extractNumbers":         extractNumbers,
 }
 
 func GetFuncMaps() template.FuncMap {
@@ -302,4 +304,10 @@ func itauEnv() string {
 		return "1"
 	}
 	return "2"
+}
+
+func extractNumbers(value string) string {
+	re := regexp.MustCompile("(\\D+)")
+	sanitizeValue := re.ReplaceAllString(string(value), "")
+	return sanitizeValue
 }

--- a/tmpl/template_test.go
+++ b/tmpl/template_test.go
@@ -140,3 +140,13 @@ func TestUnscapeHtml(t *testing.T) {
 		So(unescapeHtmlString(d), ShouldEqual, "ó")
 	})
 }
+
+func TestSanitizeCep(t *testing.T) {
+	zipCodeWithSeparator := extractNumbers("25368-100")
+	zipCodeWithoutSeparator := extractNumbers("25368100")
+
+	Convey("o zipcode deve conter apenas números", t, func() {
+		So(zipCodeWithSeparator, ShouldEqual, "25368100")
+		So(zipCodeWithoutSeparator, ShouldEqual, "25368100")
+	})
+}


### PR DESCRIPTION
**O que foi feito?**
Um método para remover qualquer caractere que não seja número.

**Por que foi feito?**
A BoletoApi não faz nenhum tratamento referente a CEP no Request que recebe. 
Há casos em que cliente BradescoShopfacil envia o CEP com traço (Ex.: 00000-000), porém o mesmo requer que apenas números seja enviado no campo ZipCode.