### PR TITLE
change response content-type to json when failing to get boleto pdf

### DIFF
--- a/api/boleto.go
+++ b/api/boleto.go
@@ -113,7 +113,11 @@ func getBoleto(c *gin.Context) {
 		c.Writer.WriteString(s)
 	} else {
 		c.Header("Content-Type", "application/pdf")
-		if buf, err := toPdf(s); err != nil {
+
+		buf, err := toPdf(s)
+
+		if err != nil {
+			c.Header("Content-Type", "application/json")
 			checkError(c, models.NewInternalServerError(err.Error(), "internal error"), log.CreateLog())
 			c.Abort()
 		} else {


### PR DESCRIPTION
What?
Change response content-type to json when failing to get boleto pdf

Why?
When the application fails to generate the boleto pdf, no errors are returned/logged because the content-type of the response is always set to "application/pdf"

How?
Setting the response content-type header to "application/json" when the call to pdf api fails