### PR TITLE
Includes new validation on return of bradescoShopFacil

### DIFF
--- a/bradescoShopFacil/response.go
+++ b/bradescoShopFacil/response.go
@@ -2,7 +2,7 @@ package bradescoShopFacil
 
 var apiResponse = `
 {
-	{{if eq .returnCode "0"}}
+	{{if or (eq .returnCode "0") (eq .returnCode "93005999")}}
        "DigitableLine": "{{fmtDigitableLine (trim .digitableLine)}}",
 		"Links": [{
 			"href":"{{.url}}",


### PR DESCRIPTION
What?
The bradescoShopFacil are returning a new value on response of your api, but boleto-api don't was treating this new value.

Why?
Our customer Reserva are integrating with bradescoShopFacil and it are receiving this new code.
