### PR TITLE
:sparkles: Fix fields with special characters

### DIFF
--- a/itau/request.go
+++ b/itau/request.go
@@ -19,15 +19,15 @@ const registerItau = `
         "conta_beneficiario": "{{padLeft .Agreement.Account "0" 7}}",
         "digito_verificador_conta_beneficiario": "{{.Agreement.AccountDigit}}"
     },
-    "identificador_titulo_empresa": "{{truncate .Recipient.Name 25}}",
+    "identificador_titulo_empresa": "{{unescapeHtmlString (truncate .Recipient.Name 25)}}",
     "uso_banco": "",
     "titulo_aceite": "S",
     "pagador": {
         "cpf_cnpj_pagador": "{{extractNumbers .Buyer.Document.Number}}",
-        "nome_pagador": "{{truncate .Buyer.Name 30}}",
-        "logradouro_pagador": "{{truncate (concat .Buyer.Address.Street " " .Buyer.Address.Number " " .Buyer.Address.Complement) 40 }}",        
-        "bairro_pagador": "{{truncate .Buyer.Address.District 15}}",
-        "cidade_pagador": "{{truncate .Buyer.Address.City 20}}",
+        "nome_pagador": "{{unescapeHtmlString (truncate .Buyer.Name 30)}}",
+        "logradouro_pagador": "{{unescapeHtmlString (truncate (concat .Buyer.Address.Street " " .Buyer.Address.Number " " .Buyer.Address.Complement) 40) }}",        
+        "bairro_pagador": "{{unescapeHtmlString (truncate .Buyer.Address.District 15)}}",
+        "cidade_pagador": "{{unescapeHtmlString (truncate .Buyer.Address.City 20)}}",
         "uf_pagador": "{{truncate .Buyer.Address.StateCode 2}}",
         "cep_pagador": "{{truncate (extractNumbers .Buyer.Address.ZipCode) 8}}",
         "grupo_email_pagador": [

--- a/itau/response.go
+++ b/itau/response.go
@@ -1,7 +1,7 @@
 package itau
 
 const registerBoletoResponseItau = `{
-    {{if (hasErrorTags . "errorCode")}}
+    {{if (hasErrorTags . "errorCode") | (hasErrorTags . "errorMessage")}}
         "Errors": [
             {                    
                 "Code": "{{trim .errorCode}}",

--- a/pefisa/response.go
+++ b/pefisa/response.go
@@ -2,7 +2,7 @@ package pefisa
 
 const registerBoletoResponsePefisa = `
 {
-    {{if (hasErrorTags . "errorCode") | (hasErrorTags . "errorMessage"}}
+    {{if (hasErrorTags . "errorCode") | (hasErrorTags . "errorMessage")}}
         "Errors": [
             {
                 "Code": "{{trim .errorCode}}",

--- a/pefisa/response.go
+++ b/pefisa/response.go
@@ -2,7 +2,7 @@ package pefisa
 
 const registerBoletoResponsePefisa = `
 {
-    {{if (hasErrorTags . "errorCode")}}
+    {{if (hasErrorTags . "errorCode") | (hasErrorTags . "errorMessage"}}
         "Errors": [
             {
                 "Code": "{{trim .errorCode}}",


### PR DESCRIPTION
**O quê?**

O Billing está com problemas para registrar boletos de lojas que possuem algum caractere especial em seus dados. No Request em anexo, o bairro pagador contém um caractere especial que, aparentemente, teve algum problema com enconding:

`"bairro_pagador ":"Olho D' Água ",`

No log é possível ver que o One recebeu e repassou a informação como: "Olho D' Água", porém a BoletoApi enviou para o banco "Olho D&#39; Água ". O que causou um erro no registro do boleto por parte do banco.