### PR TITLE
:sparkles: Remove responsabilidade excessivas do Flow

### DIFF
--- a/env/install.go
+++ b/env/install.go
@@ -45,7 +45,7 @@ func ConfigMock(port string) {
 	os.Setenv("TIMEOUT_REGISTER", "30")
 	os.Setenv("TIMEOUT_TOKEN", "20")
 	os.Setenv("TIMEOUT_DEFAULT", "50")
-	config.Install(true, true, true)
+	config.Install(true, true, false)
 }
 
 func configFlags(devMode, mockMode, disableLog bool) {
@@ -90,7 +90,7 @@ func configFlags(devMode, mockMode, disableLog bool) {
 		os.Setenv("URL_BRADESCO_NET_EMPRESA", "https://cobranca.bradesconetempresa.b.br/ibpjregistrotitulows/registrotitulohomologacao")
 		os.Setenv("RECOVERYROBOT_EXECUTION_ENABLED", "true")
 		os.Setenv("RECOVERYROBOT_EXECUTION_IN_MINUTES", "2")
-		os.Setenv("TIMEOUT_REGISTER", "30")
+		os.Setenv("TIMEOUT_REGISTER", "5")
 		os.Setenv("TIMEOUT_TOKEN", "20")
 		os.Setenv("TIMEOUT_DEFAULT", "50")
 		os.Setenv("URL_PEFISA_TOKEN", "https://psdo-hom.pernambucanas.com.br:444/sdcobr/api/oauth/token")

--- a/log/seq.go
+++ b/log/seq.go
@@ -64,8 +64,24 @@ func (l Log) Request(content interface{}, url string, headers map[string]string)
 		props := l.defaultProperties("Request", content)
 		props.AddProperty("Headers", headers)
 		props.AddProperty("URL", url)
-		action := strings.Split(url, "/")
-		msg := formatter(fmt.Sprintf("to {BankName} (%s) | {Recipient}", action[len(action)-1]))
+		msg := formatter(fmt.Sprintf("to {BankName} | {Operation}"))
+
+		l.logger.Information(msg, props)
+	})()
+}
+
+// Request loga o request para algum banco
+func (l Log) RequestCustom(content interface{}, headers map[string]string, custom map[string]string) {
+	if config.Get().DisableLog {
+		return
+	}
+	go (func() {
+		props := l.defaultProperties("Request", content)
+		props.AddProperty("Headers", headers)
+		for key, value := range custom {
+			props.AddProperty(key, value)
+		}
+		msg := formatter(fmt.Sprintf("to {BankName} | {Operation}"))
 
 		l.logger.Information(msg, props)
 	})()
@@ -81,6 +97,23 @@ func (l Log) Response(content interface{}, url string) {
 		props.AddProperty("URL", url)
 		action := strings.Split(url, "/")
 		msg := formatter(fmt.Sprintf("from {BankName} (%s) | {Recipient}", action[len(action)-1]))
+
+		l.logger.Information(msg, props)
+	})()
+}
+
+func (l Log) ResponseCustom(content interface{}, custom map[string]string) {
+	if config.Get().DisableLog {
+		return
+	}
+	go (func() {
+		props := l.defaultProperties("Response", content)
+		for key, value := range custom {
+			props.AddProperty(key, value)
+		}
+		// props.AddProperty("URL", url)
+		// action := strings.Split(url, "/")
+		msg := formatter(fmt.Sprintf("from {BankName} ({Duration}) | {Operation}"))
 
 		l.logger.Information(msg, props)
 	})()
@@ -107,7 +140,7 @@ func (l Log) ResponseApplication(content interface{}, url string) {
 		return
 	}
 	go (func() {
-		props := l.defaultProperties("Response", content)
+		props := l.defaultProperties("Result", content)
 		props.AddProperty("URL", url)
 		msg := formatter(" {Operation} | {Recipient}")
 

--- a/pefisa/response.go
+++ b/pefisa/response.go
@@ -2,7 +2,7 @@ package pefisa
 
 const registerBoletoResponsePefisa = `
 {
-    {{if (hasErrorTags . "errorCode") | (hasErrorTags . "errorMessage"}}
+    {{if (hasErrorTags . "errorCode") | (hasErrorTags . "errorMessage")}}
         "Errors": [
             {
                 "Code": "{{trim .errorCode}}",

--- a/tmpl/flow_factory.go
+++ b/tmpl/flow_factory.go
@@ -1,0 +1,46 @@
+package tmpl
+
+import (
+	"github.com/mundipagg/boleto-api/util"
+	. "github.com/PMoneda/flow"
+)
+
+//Using flow to mapping data in JSON from a contract to other
+func TransformFromJSON(content string, from string, to string, obj interface{}) (interface{}) {
+	var data Transform = Transform(content)
+	var input Transform = Transform(from)
+	var output Transform = Transform(to)
+
+	success, err := data.TransformFromJSON(input, output, GetFuncMaps())
+
+	if err != nil{
+		return err
+	}
+
+	if (obj == nil){
+		return success
+	}
+
+	result := util.ParseJSON(success, obj)
+	return result
+}
+
+//Using flow to mapping data in XML from a contract to other
+func TransformFromXML(content string, from string, to string, obj interface{}) (interface{}) {
+	var data Transform = Transform(content)
+	var input Transform = Transform(from)
+	var output Transform = Transform(to)
+
+	success, err := data.TransformFromXML(input, output, GetFuncMaps())
+
+	if err != nil{
+		return err
+	}
+
+	if (obj == nil){
+		return success
+	}
+
+	result := util.ParseJSON(success, obj)
+	return result
+}

--- a/util/time.go
+++ b/util/time.go
@@ -1,9 +1,9 @@
 package util
 
 import (
+	"fmt"
 	"strconv"
 	"time"
-
 	"github.com/mundipagg/boleto-api/log"
 )
 
@@ -43,4 +43,15 @@ func GetDurationTimeoutRequest(t string) time.Duration {
 	tTime, _ := strconv.Atoi(t)
 	tOut := time.Duration(tTime)
 	return tOut
+}
+
+func ConvertDuration(dur time.Duration) string {
+	h := dur / time.Hour
+	dur -= h * time.Hour
+    m := dur / time.Minute
+    dur -= m * time.Minute
+    s := dur / time.Second
+    dur -= s * time.Second
+    ms := dur / time.Millisecond
+    return fmt.Sprintf("%02d:%02d:%02d.%03d",h,m,s,ms)
 }


### PR DESCRIPTION
**O que?**
Hoje a BoletoApi usa o Flow para efetuar requisições para o banco, mapeamento das requisições e respostas e também para logar.

Passar a utilizar o Flow apenas para efetuar o mapeamento dos contratos.

**BANCOS FEITO:**
- Pefisa
- Itau
- Citibank
- Caixa
- BB
- BradescoShopFacil
- BradescoNetEmpresa

**BANCO FALTANTE:**
- Santander

