### PR TITLE
Influx metrics switchable

### DIFF
--- a/api/middlewares.go
+++ b/api/middlewares.go
@@ -37,20 +37,20 @@ func timingMetrics() gin.HandlerFunc {
 		end := time.Now()
 		total := end.Sub(start)
 		s := float64(total.Seconds())
-		metrics.GetTimingMetrics().Push("request-time", s)
+		metrics.PushTimingMetric("request-time", s)
 	}
 }
 
 //ParseBoleto trata a entrada de boleto em todos os requests
 func ParseBoleto() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		businessMetrics := metrics.GetBusinessMetrics()
+
 		boleto := models.BoletoRequest{}
 		errBind := c.BindJSON(&boleto)
 		if errBind != nil {
 			e := models.NewFormatError(errBind.Error())
 			checkError(c, e, log.CreateLog())
-			businessMetrics.Push("json_error", 1)
+			metrics.PushBusinessMetric("json_error", 1)
 			return
 		}
 		bank, err := bank.Get(boleto)
@@ -64,7 +64,7 @@ func ParseBoleto() gin.HandlerFunc {
 		if errFmt != nil {
 			e := models.NewFormatError(errFmt.Error())
 			checkError(c, e, log.CreateLog())
-			businessMetrics.Push(bank.GetBankNameIntegration()+"-bad-request", 1)
+			metrics.PushBusinessMetric(bank.GetBankNameIntegration()+"-bad-request", 1)
 			return
 		}
 		l := log.CreateLog()
@@ -80,7 +80,7 @@ func ParseBoleto() gin.HandlerFunc {
 		resp, _ := c.Get("boletoResponse")
 		l.ResponseApplication(resp, c.Request.URL.RequestURI())
 		tag := bank.GetBankNameIntegration() + "-status"
-		businessMetrics.Push(tag, c.Writer.Status())
+		metrics.PushBusinessMetric(tag, c.Writer.Status())
 
 	}
 }

--- a/api/rest.go
+++ b/api/rest.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"net/http/httputil"
 
+	"github.com/mundipagg/boleto-api/metrics"
+
 	"github.com/gin-gonic/gin"
 	"github.com/mundipagg/boleto-api/config"
 	"github.com/mundipagg/boleto-api/log"
@@ -21,10 +23,15 @@ func InstallRestAPI() {
 	}
 	InstallV1(router)
 	router.StaticFile("/favicon.ico", "./boleto/favicon.ico")
+	router.GET("/boleto/memory-check", memory)
 	router.GET("/boleto", getBoleto)
 	router.GET("/boleto/confirmation", confirmation)
 	router.POST("/boleto/confirmation", confirmation)
 	router.Run(config.Get().APIPort)
+}
+
+func memory(c *gin.Context) {
+	c.JSON(200, metrics.GetMemoryReport())
 }
 
 func confirmation(c *gin.Context) {

--- a/api/rest.go
+++ b/api/rest.go
@@ -23,7 +23,8 @@ func InstallRestAPI() {
 	}
 	InstallV1(router)
 	router.StaticFile("/favicon.ico", "./boleto/favicon.ico")
-	router.GET("/boleto/memory-check", memory)
+	router.GET("/boleto/memory-check/:unit", memory)
+	router.GET("/boleto/memory-check/", memory)
 	router.GET("/boleto", getBoleto)
 	router.GET("/boleto/confirmation", confirmation)
 	router.POST("/boleto/confirmation", confirmation)
@@ -31,7 +32,8 @@ func InstallRestAPI() {
 }
 
 func memory(c *gin.Context) {
-	c.JSON(200, metrics.GetMemoryReport())
+	unit := c.Param("unit")
+	c.JSON(200, metrics.GetMemoryReport(unit))
 }
 
 func confirmation(c *gin.Context) {

--- a/bradescoNetEmpresa/bradescoNetEmpresa.go
+++ b/bradescoNetEmpresa/bradescoNetEmpresa.go
@@ -6,13 +6,14 @@ import (
 	"html"
 	"time"
 
+	"github.com/mundipagg/boleto-api/metrics"
+
 	"github.com/mundipagg/boleto-api/tmpl"
 	"github.com/mundipagg/boleto-api/util"
 
 	"github.com/PMoneda/flow"
 	"github.com/mundipagg/boleto-api/config"
 	"github.com/mundipagg/boleto-api/log"
-	"github.com/mundipagg/boleto-api/metrics"
 	"github.com/mundipagg/boleto-api/models"
 	"github.com/mundipagg/boleto-api/validations"
 )
@@ -57,7 +58,7 @@ func (b bankBradescoNetEmpresa) Log() *log.Log {
 }
 
 func (b bankBradescoNetEmpresa) RegisterBoleto(boleto *models.BoletoRequest) (models.BoletoResponse, error) {
-	timing := metrics.GetTimingMetrics()
+
 	r := flow.NewFlow()
 	serviceURL := config.Get().URLBradescoNetEmpresa
 	xmlResponse := getResponseBradescoNetEmpresaXml()
@@ -77,7 +78,7 @@ func (b bankBradescoNetEmpresa) RegisterBoleto(boleto *models.BoletoRequest) (mo
 		bod.To(serviceURL, map[string]string{"method": "POST", "insecureSkipVerify": "true", "timeout": config.Get().TimeoutDefault})
 	})
 
-	timing.Push("bradesco-netempresa-register-boleto-online", duration.Seconds())
+	metrics.PushTimingMetric("bradesco-netempresa-register-boleto-online", duration.Seconds())
 	bod.To("logseq://?type=response&url="+serviceURL, b.log)
 
 	bod.To("transform://?format=xml", xmlResponse, jsonReponse)

--- a/bradescoShopFacil/bradescoShopFacil.go
+++ b/bradescoShopFacil/bradescoShopFacil.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/mundipagg/boleto-api/metrics"
+
 	"github.com/PMoneda/flow"
 	"github.com/mundipagg/boleto-api/config"
 	"github.com/mundipagg/boleto-api/log"
-	"github.com/mundipagg/boleto-api/metrics"
 	"github.com/mundipagg/boleto-api/models"
 	"github.com/mundipagg/boleto-api/tmpl"
 	"github.com/mundipagg/boleto-api/util"
@@ -57,7 +58,6 @@ func (b bankBradescoShopFacil) Log() *log.Log {
 }
 
 func (b bankBradescoShopFacil) RegisterBoleto(boleto *models.BoletoRequest) (models.BoletoResponse, error) {
-	timing := metrics.GetTimingMetrics()
 	r := flow.NewFlow()
 	serviceURL := config.Get().URLBradescoShopFacil
 	from := getResponseBradescoShopFacil()
@@ -67,7 +67,7 @@ func (b bankBradescoShopFacil) RegisterBoleto(boleto *models.BoletoRequest) (mod
 	duration := util.Duration(func() {
 		bod.To(serviceURL, map[string]string{"method": "POST", "insecureSkipVerify": "true", "timeout": config.Get().TimeoutDefault})
 	})
-	timing.Push("bradesco-shopfacil-register-boleto-online", duration.Seconds())
+	metrics.PushTimingMetric("bradesco-shopfacil-register-boleto-online", duration.Seconds())
 	bod.To("logseq://?type=response&url="+serviceURL, b.log)
 	ch := bod.Choice()
 	ch.When(flow.Header("status").IsEqualTo("201"))

--- a/caixa/caixa.go
+++ b/caixa/caixa.go
@@ -3,11 +3,12 @@ package caixa
 import (
 	"fmt"
 
+	"github.com/mundipagg/boleto-api/metrics"
+
 	"github.com/PMoneda/flow"
 
 	"github.com/mundipagg/boleto-api/config"
 	"github.com/mundipagg/boleto-api/log"
-	"github.com/mundipagg/boleto-api/metrics"
 	"github.com/mundipagg/boleto-api/models"
 	"github.com/mundipagg/boleto-api/tmpl"
 	"github.com/mundipagg/boleto-api/util"
@@ -38,7 +39,7 @@ func (b bankCaixa) Log() *log.Log {
 	return b.log
 }
 func (b bankCaixa) RegisterBoleto(boleto *models.BoletoRequest) (models.BoletoResponse, error) {
-	timing := metrics.GetTimingMetrics()
+
 	r := flow.NewFlow()
 	urlCaixa := config.Get().URLCaixaRegisterBoleto
 	from := getResponseCaixa()
@@ -49,7 +50,7 @@ func (b bankCaixa) RegisterBoleto(boleto *models.BoletoRequest) (models.BoletoRe
 	duration := util.Duration(func() {
 		bod = bod.To(urlCaixa, map[string]string{"method": "POST", "insecureSkipVerify": "true", "timeout": config.Get().TimeoutDefault})
 	})
-	timing.Push("caixa-register-time", duration.Seconds())
+	metrics.PushTimingMetric("caixa-register-time", duration.Seconds())
 	bod = bod.To("logseq://?type=response&url="+urlCaixa, b.log)
 	ch := bod.Choice()
 	ch = ch.When(flow.Header("status").IsEqualTo("200"))

--- a/citibank/citi.go
+++ b/citibank/citi.go
@@ -46,7 +46,7 @@ func (b bankCiti) Log() *log.Log {
 }
 
 func (b bankCiti) RegisterBoleto(boleto *models.BoletoRequest) (models.BoletoResponse, error) {
-	timing := metrics.GetTimingMetrics()
+
 	boleto.Title.OurNumber = calculateOurNumber(boleto)
 	r := flow.NewFlow()
 	serviceURL := config.Get().URLCiti
@@ -64,7 +64,7 @@ func (b bankCiti) RegisterBoleto(boleto *models.BoletoRequest) (models.BoletoRes
 	if err != nil {
 		return models.BoletoResponse{}, err
 	}
-	timing.Push("citibank-register-boleto-online", duration.Seconds())
+	metrics.PushTimingMetric("citibank-register-boleto-online", duration.Seconds())
 	bod.To("set://?prop=header", map[string]string{"status": strconv.Itoa(status)})
 	bod.To("set://?prop=body", responseCiti)
 	bod.To("logseq://?type=response&url="+serviceURL, b.log)

--- a/config/config.go
+++ b/config/config.go
@@ -59,8 +59,9 @@ type Config struct {
 	TimeoutRegister                 string
 	TimeoutToken                    string
 	TimeoutDefault                  string
-	URLPefisaToken                   string
-	URLPefisaRegister                string
+	URLPefisaToken                  string
+	URLPefisaRegister               string
+	EnableMetrics                   bool
 }
 
 var cnf Config
@@ -126,8 +127,9 @@ func Install(mockMode, devMode, disableLog bool) {
 		TimeoutRegister:                 os.Getenv("TIMEOUT_REGISTER"),
 		TimeoutToken:                    os.Getenv("TIMEOUT_TOKEN"),
 		TimeoutDefault:                  os.Getenv("TIMEOUT_DEFAULT"),
-		URLPefisaToken:                   os.Getenv("URL_PEFISA_TOKEN"),
-		URLPefisaRegister:                os.Getenv("URL_PEFISA_REGISTER"),
+		URLPefisaToken:                  os.Getenv("URL_PEFISA_TOKEN"),
+		URLPefisaRegister:               os.Getenv("URL_PEFISA_REGISTER"),
+		EnableMetrics:                   os.Getenv("ENABLE_METRICS") == "true",
 	}
 }
 

--- a/devops/Dockerfile
+++ b/devops/Dockerfile
@@ -16,7 +16,7 @@ COPY --from=build-env ./deploy/ .
 RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 
 ENV GOROOT="/home/mundipagg/"
-ENV INFLUXDB_HOST="http://localhost"
+ENV INFLUXDB_HOST="http://influxdb"
 ENV INFLUXDB_PORT="8086"
 ENV PDF_API="http://localhost:7070/topdf"
 ENV API_PORT="3000"
@@ -54,7 +54,7 @@ ENV URL_BRADESCO_NET_EMPRESA="https://cobranca.bradesconetempresa.b.br/ibpjregis
 ENV TIMEOUT_REGISTER="30"
 ENV TIMEOUT_TOKEN="20"
 ENV TIMEOUT_DEFAULT="50"
-
+ENV ENABLE_METRICS="true"
 
 ENTRYPOINT ["/home/mundipagg/boleto-api"]
 EXPOSE 3000

--- a/devops/docker-compose.yml
+++ b/devops/docker-compose.yml
@@ -1,80 +1,80 @@
 version: '2'
 
 services:
-  # boleto-api:
-  #   build: 
-  #     context: ..
-  #     dockerfile: ./devops/Dockerfile      
-  #   volumes:
-  #     - $GOPATH/src/github.com/mundipagg/volumes-boletoapi/boleto_json_store/:/home/mundipagg/upMongo
-  #     - $GOPATH/src/github.com/mundipagg/volumes-boletoapi/cert_boleto_api/:/home/mundipagg/boleto_cert/
-  #   ports:
-  #     - "3000:3000"
-  #   links:
-  #     - pdfapi
-  #     - mongodb
-  #     - seq
-  #     - influxdb
-    
-  pdfapi:
-    image: "pmoneda/pdfapi"
-    ports:
-      - "7070:8080"
-    
-  mongodb:
-    image: "bitnami/mongodb"
-    volumes:
-      - $GOPATH/src/github.com/mundipagg/volumes-boletoapi/mongodb-boleto:/bitnami
-    ports: 
-      - "27017:27017"
-
-  seq:
-    image: "datalust/seq:latest"
-    ports:
-      - "5341:5341"
-      - "8070:80"
-    volumes:
-      - $GOPATH/src/github.com/mundipagg/volumes-boletoapi/seq_boleto/:/data
-    environment:
-      - ACCEPT_EULA=Y
+    boleto-api:
+        build: 
+          context: ..
+          dockerfile: ./devops/Dockerfile      
+        volumes:
+          - $gopath/src/github.com/mundipagg/volumes-boletoapi/boleto_json_store/:/home/mundipagg/upmongo
+          - $gopath/src/github.com/mundipagg/volumes-boletoapi/cert_boleto_api/:/home/mundipagg/boleto_cert/
+        ports:
+          - "3000:3000"
+        links:
+          - pdfapi
+          - mongodb
+          - seq
+          - influxdb
   
-  redis:
-    image: "bitnami/redis:latest"
-    ports:
-      - "6379:6379"
-    environment:
-      - REDIS_PASSWORD=123456
-    volumes:
-      - $GOPATH/src/github.com/mundipagg/volumes-boletoapi/redis-boleto:/bitnami/redis/data
+    pdfapi:
+        image: "pmoneda/pdfapi"
+        ports:
+          - "7070:8080"
 
-  influxdb:
-    image: influxdb:latest
-    container_name: influxdb
-    volumes:
-      - $GOPATH/src/github.com/mundipagg/volumes-boletoapi/influxdb-boleto/influxdb/influxdb-lib:/var/lib/influxdb
-    ports:
-      - 8086:8086
+    mongodb:
+        image: "bitnami/mongodb"
+        volumes:
+          - $GOPATH/src/github.com/mundipagg/volumes-boletoapi/mongodb-boleto:/bitnami
+        ports: 
+          - "27017:27017"
 
-  grafana:
-    image: grafana/grafana:latest
-    volumes:
-      - $GOPATH/src/github.com/mundipagg/volumes-boletoapi/influxdb-boleto/grafana/grafana-lib:/var/lib/grafana
-      - $GOPATH/src/github.com/mundipagg/volumes-boletoapi/influxdb-boleto/grafana/grafana-log:/var/log/grafana
-    links:
-      - influxdb:influxdb
-    ports:
-      - 3030:3000
-    links:
-      - influxdb
-    
-  chronograf:
-    image: chronograf:latest
-    volumes:
-      - $GOPATH/src/github.com/mundipagg/volumes-boletoapi/influxdb-boleto/chronograf:/var/lib/chronograf
-    ports:
-      - "8888:8888"
-    links:
-      - influxdb
+    seq:
+        image: "datalust/seq:latest"
+        ports:
+          - "5341:5341"
+          - "8070:80"
+        volumes:
+          - $GOPATH/src/github.com/mundipagg/volumes-boletoapi/seq_boleto/:/data
+        environment:
+          - ACCEPT_EULA=Y
+
+    redis:
+        image: "bitnami/redis:latest"
+        ports:
+          - "6379:6379"
+        environment:
+          - REDIS_PASSWORD=123456
+        volumes:
+          - $GOPATH/src/github.com/mundipagg/volumes-boletoapi/redis-boleto:/bitnami/redis/data
+
+    influxdb:
+        image: influxdb:latest
+        container_name: influxdb
+        volumes:
+          - $GOPATH/src/github.com/mundipagg/volumes-boletoapi/influxdb-boleto/influxdb/influxdb-lib:/var/lib/influxdb
+        ports:
+          - 8086:8086
+
+    grafana:
+        image: grafana/grafana:latest
+        volumes:
+          - $GOPATH/src/github.com/mundipagg/volumes-boletoapi/influxdb-boleto/grafana/grafana-lib:/var/lib/grafana
+          - $GOPATH/src/github.com/mundipagg/volumes-boletoapi/influxdb-boleto/grafana/grafana-log:/var/log/grafana
+        links:
+          - influxdb:influxdb
+        ports:
+          - 3030:3000
+        links:
+          - influxdb
+
+    chronograf:
+        image: chronograf:latest
+        volumes:
+          - $GOPATH/src/github.com/mundipagg/volumes-boletoapi/influxdb-boleto/chronograf:/var/lib/chronograf
+        ports:
+          - "8888:8888"
+        links:
+          - influxdb
 
     
         

--- a/env/install.go
+++ b/env/install.go
@@ -95,6 +95,7 @@ func configFlags(devMode, mockMode, disableLog bool) {
 		os.Setenv("TIMEOUT_DEFAULT", "50")
 		os.Setenv("URL_PEFISA_TOKEN", "https://psdo-hom.pernambucanas.com.br:444/sdcobr/api/oauth/token")
 		os.Setenv("URL_PEFISA_REGISTER", "https://psdo-hom.pernambucanas.com.br:444/sdcobr/api/v2/titulos")
+		os.Setenv("ENABLE_METRICS", "true")
 	}
 	config.Install(mockMode, devMode, disableLog)
 }

--- a/metrics/business.go
+++ b/metrics/business.go
@@ -8,16 +8,19 @@ import (
 
 var business *Telemetry
 
+//InstallBusinessMetrics Instância a telemetria de negócio
 func InstallBusinessMetrics(cnf registry.Config) {
 	value := Database("boleto-api").RetentionPolicy("business").Measurement("boletos").Tag("host").Value("host0")
 	business = BuildTelemetryContext(cnf, Context(value))
 	go business.StartTelemetry(true)
 }
 
+//GetBusinessMetrics Obtém um objeto de telemetria do negócio
 func GetBusinessMetrics() *Telemetry {
 	return business
 }
 
+//PushBusinessMetric Envio dados de negócio para a telemetria
 func PushBusinessMetric(tag string, value interface{}) {
 	if config.Get().EnableMetrics {
 		GetBusinessMetrics().Push(tag, value)

--- a/metrics/business.go
+++ b/metrics/business.go
@@ -1,7 +1,10 @@
 package metrics
 
-import "github.com/PMoneda/telemetry/registry"
-import . "github.com/PMoneda/telemetry"
+import (
+	. "github.com/PMoneda/telemetry"
+	"github.com/PMoneda/telemetry/registry"
+	"github.com/mundipagg/boleto-api/config"
+)
 
 var business *Telemetry
 
@@ -13,4 +16,10 @@ func InstallBusinessMetrics(cnf registry.Config) {
 
 func GetBusinessMetrics() *Telemetry {
 	return business
+}
+
+func PushBusinessMetric(tag string, value interface{}) {
+	if config.Get().EnableMetrics {
+		GetBusinessMetrics().Push(tag, value)
+	}
 }

--- a/metrics/install.go
+++ b/metrics/install.go
@@ -6,10 +6,12 @@ import (
 )
 
 func Install() {
-	cnf := registry.Config{}
-	cnf.Host = config.Get().InfluxDBHost
-	cnf.Port = config.Get().InfluxDBPort
-	InstallRuntime(cnf)
-	InstallTimingMetrics(cnf)
-	InstallBusinessMetrics(cnf)
+	if config.Get().EnableMetrics {
+		cnf := registry.Config{}
+		cnf.Host = config.Get().InfluxDBHost
+		cnf.Port = config.Get().InfluxDBPort
+		InstallRuntime(cnf)
+		InstallTimingMetrics(cnf)
+		InstallBusinessMetrics(cnf)
+	}
 }

--- a/metrics/install.go
+++ b/metrics/install.go
@@ -5,6 +5,7 @@ import (
 	"github.com/mundipagg/boleto-api/config"
 )
 
+//Install Inicia telemetria
 func Install() {
 	if config.Get().EnableMetrics {
 		cnf := registry.Config{}

--- a/metrics/memory.go
+++ b/metrics/memory.go
@@ -2,7 +2,12 @@ package metrics
 
 import (
 	"runtime"
+	"strings"
 )
+
+var sizeKB float64 = 1 << (10 * 1)
+var sizeMB float64 = 1 << (10 * 2)
+var sizeGB float64 = 1 << (10 * 3)
 
 type MemoryReport struct {
 	Goroutines     int     `json:"goroutines"`
@@ -15,19 +20,31 @@ type MemoryReport struct {
 	MemoryUnit     string  `json:"memoryUnit"`
 }
 
-const megabyte = 1048576.0
-
-func GetMemoryReport() MemoryReport {
+func GetMemoryReport(u string) MemoryReport {
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
+
+	var unit float64
+
+	switch strings.ToUpper(u) {
+	case "GB":
+		unit = sizeGB
+		break
+	case "KB":
+		unit = sizeKB
+	default:
+		u = "MB"
+		unit = sizeMB
+	}
+
 	return MemoryReport{
 		Goroutines:     runtime.NumGoroutine(),
-		HeapAllocated:  float64(m.HeapSys-m.HeapReleased) / megabyte,
-		HeapInUse:      float64(m.HeapInuse) / megabyte,
-		StackAllocated: float64(m.StackSys) / megabyte,
-		StackInUse:     float64(m.StackInuse) / megabyte,
-		TotalAllocated: float64(m.HeapSys+m.StackSys-m.HeapReleased) / megabyte,
-		TotalInUse:     float64(m.HeapInuse+m.StackInuse) / megabyte,
-		MemoryUnit:     "MB",
+		HeapAllocated:  float64(m.HeapSys-m.HeapReleased) / unit,
+		HeapInUse:      float64(m.HeapInuse) / unit,
+		StackAllocated: float64(m.StackSys) / unit,
+		StackInUse:     float64(m.StackInuse) / unit,
+		TotalAllocated: float64(m.HeapSys+m.StackSys-m.HeapReleased) / unit,
+		TotalInUse:     float64(m.HeapInuse+m.StackInuse) / unit,
+		MemoryUnit:     strings.ToUpper(u),
 	}
 }

--- a/metrics/memory.go
+++ b/metrics/memory.go
@@ -9,6 +9,7 @@ var sizeKB float64 = 1 << (10 * 1)
 var sizeMB float64 = 1 << (10 * 2)
 var sizeGB float64 = 1 << (10 * 3)
 
+//MemoryReport Contrato de Memory Check
 type MemoryReport struct {
 	Goroutines     int     `json:"goroutines"`
 	HeapAllocated  float64 `json:"heapAllocated"`
@@ -20,6 +21,7 @@ type MemoryReport struct {
 	MemoryUnit     string  `json:"memoryUnit"`
 }
 
+//GetMemoryReport Obtém dados de Memory Check
 func GetMemoryReport(u string) MemoryReport {
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)

--- a/metrics/memory.go
+++ b/metrics/memory.go
@@ -1,0 +1,33 @@
+package metrics
+
+import (
+	"runtime"
+)
+
+type MemoryReport struct {
+	Goroutines     int     `json:"goroutines"`
+	HeapAllocated  float64 `json:"heapAllocated"`
+	HeapInUse      float64 `json:"heapInUse"`
+	StackAllocated float64 `json:"stackAllocated"`
+	StackInUse     float64 `json:"stackInUse"`
+	TotalAllocated float64 `json:"totalAllocated"`
+	TotalInUse     float64 `json:"totalInUse"`
+	MemoryUnit     string  `json:"memoryUnit"`
+}
+
+const megabyte = 1048576.0
+
+func GetMemoryReport() MemoryReport {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return MemoryReport{
+		Goroutines:     runtime.NumGoroutine(),
+		HeapAllocated:  float64(m.HeapSys-m.HeapReleased) / megabyte,
+		HeapInUse:      float64(m.HeapInuse) / megabyte,
+		StackAllocated: float64(m.StackSys) / megabyte,
+		StackInUse:     float64(m.StackInuse) / megabyte,
+		TotalAllocated: float64(m.HeapSys+m.StackSys-m.HeapReleased) / megabyte,
+		TotalInUse:     float64(m.HeapInuse+m.StackInuse) / megabyte,
+		MemoryUnit:     "MB",
+	}
+}

--- a/metrics/timing.go
+++ b/metrics/timing.go
@@ -8,16 +8,19 @@ import (
 
 var timing *Telemetry
 
+//InstallTimingMetrics Instância a telemetria de tempo de resposta
 func InstallTimingMetrics(cnf registry.Config) {
 	value := Database("boleto-api").RetentionPolicy("runtime").Measurement("timing").Tag("host").Value("host0")
 	timing = BuildTelemetryContext(cnf, Context(value))
 	go timing.StartTelemetry(true)
 }
 
+//GetTimingMetrics Obtém um objeto de telemetria do tempo de resposta
 func GetTimingMetrics() *Telemetry {
 	return timing
 }
 
+//PushTimingMetric Envio dados de tempo de resposta para a telemetria
 func PushTimingMetric(tag string, value interface{}) {
 	if config.Get().EnableMetrics {
 		GetTimingMetrics().Push(tag, value)

--- a/metrics/timing.go
+++ b/metrics/timing.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	. "github.com/PMoneda/telemetry"
 	"github.com/PMoneda/telemetry/registry"
+	"github.com/mundipagg/boleto-api/config"
 )
 
 var timing *Telemetry
@@ -15,4 +16,10 @@ func InstallTimingMetrics(cnf registry.Config) {
 
 func GetTimingMetrics() *Telemetry {
 	return timing
+}
+
+func PushTimingMetric(tag string, value interface{}) {
+	if config.Get().EnableMetrics {
+		GetTimingMetrics().Push(tag, value)
+	}
 }

--- a/santander/santander.go
+++ b/santander/santander.go
@@ -50,7 +50,6 @@ func (b bankSantander) Log() *log.Log {
 	return b.log
 }
 func (b bankSantander) GetTicket(boleto *models.BoletoRequest) (string, error) {
-	timing := metrics.GetTimingMetrics()
 	boleto.Title.OurNumber = calculateOurNumber(boleto)
 	pipe := NewFlow()
 	url := config.Get().URLTicketSantander
@@ -60,7 +59,7 @@ func (b bankSantander) GetTicket(boleto *models.BoletoRequest) (string, error) {
 	duration := util.Duration(func() {
 		pipe.To(tlsURL, b.transport, map[string]string{"timeout": config.Get().TimeoutToken})
 	})
-	timing.Push("santander-get-ticket-boleto-time", duration.Seconds())
+	metrics.PushTimingMetric("santander-get-ticket-boleto-time", duration.Seconds())
 	pipe.To("logseq://?type=response&url="+url, b.log)
 	ch := pipe.Choice()
 	ch.When(Header("status").IsEqualTo("200"))
@@ -82,7 +81,6 @@ func (b bankSantander) GetTicket(boleto *models.BoletoRequest) (string, error) {
 }
 
 func (b bankSantander) RegisterBoleto(input *models.BoletoRequest) (models.BoletoResponse, error) {
-	timing := metrics.GetTimingMetrics()
 	serviceURL := config.Get().URLRegisterBoletoSantander
 	fromResponse := getResponseSantander()
 	toAPI := getAPIResponseSantander()
@@ -94,7 +92,7 @@ func (b bankSantander) RegisterBoleto(input *models.BoletoRequest) (models.Bolet
 	duration := util.Duration(func() {
 		exec.To(santanderURL, b.transport, map[string]string{"method": "POST", "insecureSkipVerify": "true", "timeout": config.Get().TimeoutRegister})
 	})
-	timing.Push("santander-register-boleto-time", duration.Seconds())
+	metrics.PushTimingMetric("santander-register-boleto-time", duration.Seconds())
 	exec.To("logseq://?type=response&url="+serviceURL, b.log)
 	ch := exec.Choice()
 	ch.When(Header("status").IsEqualTo("200"))


### PR DESCRIPTION
# Descrição

### Tarefa [CA-414](https://mundipagg.atlassian.net/secure/RapidBoard.jspa?rapidView=76&projectKey=CA&modal=detail&selectedIssue=CA-414)

Permite habilitar/desabilitar a monitoria via o pacote de telemetria através da variável booleana de configuração ENABLE_METRICS, dando maior versatilidade e desacoplamento. Além disso, foi inserido o endpoint **/boleto/memory-check** que retorna informações referentes a alocação de memória e _goroutines_, a saber:

- **goroutines**: Número de GoRoutines;
- **heapAllocated**: Alocação referente ao espaço memória dinâmica _(Heap)_ da aplicação;
- **heapInUse**: Memória do Heap em uso;
- **stackAllocated**: Alocação referente a pilha memória _(Stack)_ reservada pelo SO para a aplicação;
- **stackInUse**: Memória da Stack em uso;
- **totalAllocated**: Alocação referente a pilha memória _(Stack)_ reservada pelo SO para a aplicação;
- **stackInUse**: Memória da Stack em uso;
- **memoryUnit**: Unidade de medida das informações referentes à memória. Por padrão a unidade utilizada será _Megabytes_**(MB)**. Pode ser utilizado a rota `/boleto/memory-check/kb` para receber a resposta em  _Kilobytes_**(KB)** ou  `/boleto/memory-check/gb` para receber a resposta em  _Gigabytes_**(GB)** 

**Examplo de Resposta do MemoryCheck**
```JSON
{
    "goroutines": 10,
    "heapAllocated": 63.5,
    "heapInUse": 1.8203125,
    "stackAllocated": 0.5,
    "stackInUse": 0.5,
    "totalAllocated": 64,
    "totalInUse": 2.3203125,
    "memoryUnit": "MB"
}
```

### Tipos de alterações

- [ ] Correção de bug 
- [ ] Nova feature 
- [X] Alteração ou remoção de funcionalidade existente
- [ ] Atualização de documentação

## Testes

Para realização dos testes foi realizada a execução de requisições via Postman com a flag **ENABLE_METRICS** habilitada e desabilitada. Quando habilitada, haverá alimentação de dados nas ferramentas de telemetria. Quando desabilitada, não serão enviados dados de telemetria.

Foram executados os testes da collection do Postman **BoletoApi - Requests**

![image](https://user-images.githubusercontent.com/18493760/54396558-316e6a00-4692-11e9-8970-388b75bc117a.png)

- [ ] Coleção do Postman com testes executados está anexado na tarefa.

### Teste ENABLE_METRICS = true
Quando a flag de métrica está habilitada o envio dos dados ocorre normalmente

![image](https://user-images.githubusercontent.com/18493760/54319797-898d6980-45c9-11e9-8757-6a803256b925.png)

### Teste ENABLE_METRICS = false
Quando a flag de métrica está desabilitada o envio dos dados não é realizado. 

![image](https://user-images.githubusercontent.com/18493760/54320171-d1f95700-45ca-11e9-8eea-0a68e7191fa9.png)


### Teste MemoryCheck

Foi realizado o teste do novo endpoint de MemoryCheck. O teste foi realizado tanto com a unidade padrão (MB) quanto com kilobytes (KB):

![image](https://user-images.githubusercontent.com/18493760/54320523-06b9de00-45cc-11e9-8a53-05fd0953daa3.png)

![image](https://user-images.githubusercontent.com/18493760/54320655-74fea080-45cc-11e9-8613-2c41185b6c94.png)

### GoConvey
Foi executada a bateria de testes via GoConvey com sucesso

![image](https://user-images.githubusercontent.com/18493760/54647113-28a9d980-4a80-11e9-8356-04e20442d2bf.png)

## Checklist

- [x] Meu código segue as diretrizes desse projeto.
- [x] Eu revisei meu próprio código.
- [x] Eu comentei meu código em áreas particulares de difícil compreensão.
- [x] Eu atualizei a documentação de acordo com as mudanças realizadas.
- [x] Meu código não gerou novos warnings.
- [x] Eu adicionei testes que provam que minha correção é efetiva ou que a nova feature funciona.
- [x] Testes novos e existentes passam localmente com minhas alterações. 
- [ ] Testes novos e existentes passam em staging com minhas alterações. 
- [x] Qualquer dependência dessa alteração já foi mergeada e publicada.