### PR TITLE
:art: hotfix/remove-bb-zipcode-hyphen

### DIFF
--- a/bb/request.go
+++ b/bb/request.go
@@ -50,7 +50,7 @@ const registerBoleto = `
  <sch:numeroInscricaoPagador>{{clearString (truncate .Buyer.Document.Number 15)}}</sch:numeroInscricaoPagador>
  <sch:nomePagador>{{clearString (truncate .Buyer.Name 60)}}</sch:nomePagador>
  <sch:textoEnderecoPagador>{{clearString (truncate .Buyer.Address.Street 60)}}</sch:textoEnderecoPagador>
- <sch:numeroCepPagador>{{.Buyer.Address.ZipCode}}</sch:numeroCepPagador>
+ <sch:numeroCepPagador>{{extractNumbers .Buyer.Address.ZipCode}}</sch:numeroCepPagador>
  <sch:nomeMunicipioPagador>{{clearString (truncate .Buyer.Address.City 20)}}</sch:nomeMunicipioPagador>
  <sch:nomeBairroPagador>{{clearString (truncate .Buyer.Address.District 20)}}</sch:nomeBairroPagador>
  <sch:siglaUfPagador>{{clearString (truncate .Buyer.Address.StateCode 2)}}</sch:siglaUfPagador> 


### PR DESCRIPTION
# Descrição

### Tarefa [PAG-221](https://mundipagg.atlassian.net/secure/RapidBoard.jspa?rapidView=125&modal=detail&selectedIssue=PAG-221) 

Implementa função que remove hífen/letras do CEP para boletos do banco do brasil.
Para requisições de boletos do banco-do-brasil, o banco está recusando transações que vão com hífen.

### Tipos de alterações

- [x] Correção de bug 
- [ ] Nova feature 
- [ ] Alteração ou remoção de funcionalidade existente
- [ ] Atualização de documentação

### Coleção de Testes [Download](https://www.getpostman.com/collections/0e2f291ff45ca4be2666)

## Enviando com hífen na requisição, mas no momento de mandar para o banco, está sem Hífen

![1](https://user-images.githubusercontent.com/29386600/63556085-d0d53a00-c519-11e9-9cd9-fcbaabc30d66.PNG)

![2](https://user-images.githubusercontent.com/29386600/63556082-d03ca380-c519-11e9-94ce-63f3508dbe1f.PNG)

- [x] Associei corretamente a Tarefa do Board ao Pull Request.
- [x] Meu código segue as diretrizes desse projeto.
- [x] Eu revisei meu próprio código.
- [ ] Eu comentei meu código em áreas particulares de difícil compreensão.
- [ ] Eu atualizei a documentação de acordo com as mudanças realizadas.
- [x] Meu código não gerou novos warnings.
- [x] Eu adicionei testes que provam que minha correção é efetiva ou que a nova feature funciona.
- [x] Testes novos e existentes passam localmente com minhas alterações. 
- [x] Testes novos e existentes passam em staging com minhas alterações. 
- [x] Qualquer dependência dessa alteração já foi realizada (deploy, configuração em todos os ambientes, etc).
