### PR TITLE
:art: escapa caracteres de marcacao no request itau

### DIFF
--- a/itau/request.go
+++ b/itau/request.go
@@ -25,11 +25,11 @@ const registerItau = `
     "pagador": {
         "cpf_cnpj_pagador": "{{extractNumbers .Buyer.Document.Number}}",
         "nome_pagador": "{{unescapeHtmlString (truncate .Buyer.Name 30)}}",
-        "logradouro_pagador": "{{unescapeHtmlString (truncate (concat .Buyer.Address.Street " " .Buyer.Address.Number " " .Buyer.Address.Complement) 40) }}",        
-        "bairro_pagador": "{{unescapeHtmlString (truncate .Buyer.Address.District 15)}}",
-        "cidade_pagador": "{{unescapeHtmlString (truncate .Buyer.Address.City 20)}}",
+        "logradouro_pagador": "{{unescapeHtmlString ( escapeStringOnJson (truncate (concat .Buyer.Address.Street " " .Buyer.Address.Number " " .Buyer.Address.Complement) 40)) }}",        
+        "bairro_pagador": "{{unescapeHtmlString ( escapeStringOnJson (truncate .Buyer.Address.District 15))}}",
+        "cidade_pagador": "{{unescapeHtmlString ( escapeStringOnJson (truncate .Buyer.Address.City 20))}}",
         "uf_pagador": "{{truncate .Buyer.Address.StateCode 2}}",
-        "cep_pagador": "{{truncate (extractNumbers .Buyer.Address.ZipCode) 8}}",
+        "cep_pagador": "{{escapeStringOnJson (truncate (extractNumbers .Buyer.Address.ZipCode) 8)}}",
         "grupo_email_pagador": [
             {
                 "email_pagador": ""


### PR DESCRIPTION
# Descrição

### Tarefa [TRAN-75](https://mundipagg.atlassian.net/secure/RapidBoard.jspa?rapidView=171&projectKey=TRAN&modal=detail&selectedIssue=TRAN-75) 

Ao enviar registro de boleto para o Itaú, encontramos um erro gerado no próprio banco quando o logista envia na requisição um caractere de tabulação na string dos campos do comprador.


### Tipos de alterações

- [x] Correção de bug 
- [ ] Nova feature 
- [ ] Alteração ou remoção de funcionalidade existente
- [ ] Atualização de documentação

## Testes


### Coleção de Testes [Download](https://www.getpostman.com/collections/586aa325ae77fbb70ffe)

### Teste A

Enviada uma requisição para o Itaú com os campos com o caractere inválido.
![image](https://user-images.githubusercontent.com/15247622/69173469-9c542880-0ade-11ea-8821-44564f6c78ee.png)

## Checklist

- [x] Associei corretamente a Tarefa do Board ao Pull Request.
- [x] Meu código segue as diretrizes desse projeto.
- [x] Eu revisei meu próprio código.
- [ ] Eu comentei meu código em áreas particulares de difícil compreensão.
- [ ] Eu atualizei a documentação de acordo com as mudanças realizadas.
- [x] Meu código não gerou novos warnings.
- [x] Eu adicionei testes que provam que minha correção é efetiva ou que a nova feature funciona.
- [x] Testes novos e existentes passam localmente com minhas alterações. 
- [x] Testes novos e existentes passam em staging com minhas alterações. 
- [x] Qualquer dependência dessa alteração já foi realizada (deploy, configuração em todos os ambientes, etc).
