### PR TITLE
Feature/bproc 37 validate special character

### DIFF
--- a/citibank/request.go
+++ b/citibank/request.go
@@ -27,12 +27,12 @@ const registerBoletoCiti = `
             <CdClrSys>745</CdClrSys>
             <CdIspb>33479023</CdIspb>
             <CdtrId>{{.Authentication.Username}}</CdtrId>
-            <CdtrNm>{{truncate .Recipient.Name 40}}</CdtrNm>
+            <CdtrNm>{{sanitizeCitibankSpecialCharacteres .Recipient.Name 40}}</CdtrNm>
             <CdtrTaxId>{{truncate .Recipient.Document.Number 14}}</CdtrTaxId>
             <CdtrTaxTp>J</CdtrTaxTp>
          </GrpBenf>
          <GrpClPgd>
-            <DbtrNm>{{clearString (truncate .Buyer.Name 50)}}</DbtrNm>
+            <DbtrNm>{{sanitizeCitibankSpecialCharacteres .Buyer.Name 50}}</DbtrNm>
             <DbtrTaxId>{{clearString (truncate .Buyer.Document.Number 14)}}</DbtrTaxId>
 			{{if (eq .Buyer.Document.Type "CPF")}}
             	<DbtrTaxTp>F</DbtrTaxTp>
@@ -40,7 +40,7 @@ const registerBoletoCiti = `
             	<DbtrTaxTp>J</DbtrTaxTp>
 			{{end}}
             <GrpClPgdAdr>
-               <DbtrAdrTp>{{clearString (truncate (joinSpace .Buyer.Address.Street .Buyer.Address.Number .Buyer.Address.Complement) 40)}}</DbtrAdrTp>
+               <DbtrAdrTp>{{sanitizeCitibankSpecialCharacteres (joinSpace .Buyer.Address.Street .Buyer.Address.Number .Buyer.Address.Complement) 40}}</DbtrAdrTp>
                <DbtrCtrySubDvsn>{{clearString (truncate .Buyer.Address.StateCode 2)}}</DbtrCtrySubDvsn>
                <DbtrPstCd>{{truncate (extractNumbers .Buyer.Address.ZipCode) 8}}</DbtrPstCd>
                <DbtrTwnNm>{{clearString (truncate .Buyer.Address.City 15)}}</DbtrTwnNm>
@@ -48,7 +48,7 @@ const registerBoletoCiti = `
          </GrpClPgd>
          <CdOccTp>01</CdOccTp>
          <DbtrGrntNm> </DbtrGrntNm>
-         <DbtrMsg>{{sanitizeCitibakSpecialCharacteres .Title.Instructions 40}}</DbtrMsg>
+         <DbtrMsg>{{sanitizeCitibankSpecialCharacteres .Title.Instructions 40}}</DbtrMsg>
          <TitlAmt>{{.Title.AmountInCents}}</TitlAmt>
          <TitlBarCdInd>0</TitlBarCdInd>
          <TitlCcyCd>09</TitlCcyCd>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,3 +3,6 @@ sonar.projectName=boleto-api
 
 sonar.sources=.
 sonar.exclusions=**/*_test.go,**/vendor/**
+
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go

--- a/tmpl/funcmaps.go
+++ b/tmpl/funcmaps.go
@@ -68,7 +68,7 @@ var funcMap = template.FuncMap{
 	"truncateManyFields":                truncateManyFields,
 	"escapeStringOnJson":                escapeStringOnJson,
 	"removeSpecialCharacter":            removeSpecialCharacter,
-	"sanitizeCitibakSpecialCharacteres": sanitizeCitibakSpecialCharacteres,
+	"sanitizeCitibankSpecialCharacteres": sanitizeCitibankSpecialCharacteres,
 }
 
 func GetFuncMaps() template.FuncMap {
@@ -393,11 +393,12 @@ func removeSpecialCharacter(str string) string {
 	return regexp.MustCompile("[^a-zA-Z0-9ÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕáéíóúàèìòùâêîôûãõç,.\\-\\s]+").ReplaceAllString(str, "")
 }
 
-func sanitizeCitibakSpecialCharacteres(str string, num int) string {
+func sanitizeCitibankSpecialCharacteres(str string, num int) string {
+	str = regexp.MustCompile("[^a-zA-Z0-9.;@\\-\\/\\s]+").ReplaceAllString(clearString(str), "")
+	
 	if len(str) > num {
 		str = str[0:num]
 	}
-	str = regexp.MustCompile("[^a-zA-Z0-9.;@\\-\\/\\s]+").ReplaceAllString(clearString(str), "")
-	
+
 	return str
 }

--- a/tmpl/funcmaps_test.go
+++ b/tmpl/funcmaps_test.go
@@ -61,6 +61,16 @@ var mod11BradescoShopFacilDvParameters = []test.Parameter{
 	{Input: "00000000002", Expected: "8"},
 }
 
+var sanitizeCitibankSpecialCharacteresParameters = []test.Parameter{
+	{Input: "", Length: 0, Expected: ""}, //Default string value
+	{Input: "   ", Length: 3, Expected: "   "}, //Whitespaces
+	{Input: "a b", Length: 3, Expected: "a b"},
+	{Input: "/-;@", Length: 4, Expected: "/-;@"}, //Caracteres especiais aceitos pelo Citibank
+	{Input: "???????????????????????????a-zA-Z0-9ÁÉÍÓÚÀÈÌÒÙÂÊÎÔÛÃÕáéíóúàèìòùâêîôûãõç.", Length: 45, Expected: "a-zA-Z0-9AEIOUAEIOUAEIOUAOaeiouaeiouaeiouaoc."},
+	{Input: "Ol@ Mundo. você pode ver uma barra /, mas não uma exclamação!?; Nem Isso", Length: 60, Expected: "Ol@ Mundo. voce pode ver uma barra / mas nao uma exclamacao;"},
+	{Input: "Avenida Andr? Rodrigues de Freitas", Length: 33, Expected: "Avenida Andr Rodrigues de Freitas"},
+}
+
 func TestShouldPadLeft(t *testing.T) {
 	expected := "00005"
 
@@ -218,10 +228,11 @@ func TestRemoveCharacterSpecial(t *testing.T) {
 	assert.Equal(t, expected, result, "Os caracteres especiais devem ser removidos")
 }
 
-func TestCitBankSanitizeString(t *testing.T) {
-	expected := "Ol@ Mundo. voce pode ver uma barra / mas nao uma exclamacao;"
-
-	result := sanitizeCitibakSpecialCharacteres("Ol@ Mundo. você pode ver uma barra /, mas não uma exclamação!?; Nem Isso", 67)
-
-	assert.Equal(t, expected, result, "Caracteres especiais e acendos devem ser removidos")
+func TestCitiBankSanitizeString(t *testing.T) {
+	for _, fact := range sanitizeCitibankSpecialCharacteresParameters {
+		input := fact.Input.(string)
+		result := sanitizeCitibankSpecialCharacteres(input, fact.Length)
+		assert.Equal(t, fact.Expected, result, "Caracteres especiais e acentos devem ser removidos")
+		assert.Equal(t, fact.Length, len(result), "O texto deve ser devidamente truncado")
+	}
 }


### PR DESCRIPTION
# Descrição

### Tarefa [BPROC-37](https://mundipagg.atlassian.net/browse/BPROC-37) 

Alguns registros vêm sendo negados no Citibank por conta do caractere `?` no campos de endereço do comprador.  

### Pontos de alteração

1. **Sanitização de Campos**: O Citibank possuí uma regra de sanitização própria, descrita em sua documentação, com os caracteres especiais aceitos. Atualmente essa regra já é aplicada para o campo de _title.instructions_. Segundo o manual essa regra deverá ser aplicada aos campos: _recipient.name_, _buyer.name_, buyer.address (rua e complemento). 

Assim utilizamos a _funcmap_ `sanitizeCitibankSpecialCharacteres` para tratar os referidos campos no template de `request.go` do pacote `citibank`.

2. **Alteração do lógica da _sanitizeCitibankSpecialCharacteres_**: Anteriormente a função realizava o _truncate_ da _string_ para o valor parametrizado e só depois sanitizava a _string_. Com isso, uma _string_ poderia apresentar menos caracteres, uma vez que a sanitização poderá remover caracteres especiais. A string ` "???texto excluir"` limitada a 5 caracteres, por exemplo,  ao invés de virar `"texto"` seria convertida em `"tex"`, pois seria aplicado primeiro o _truncate_ e depois a sanitização.

### Tipos de alterações

- [x] Correção de bug 
- [ ] Nova feature 
- [ ] Alteração ou remoção de funcionalidade existente
- [ ] Atualização de documentação

## Testes

Além dos testes unitários da função realizamos um teste local fazendo uma requisição com diversos caracteres especiais nos campos supracitados.

### Coleção de Testes [Download](https://www.getpostman.com/collections/83ff1739e979805b1ff6)

### Teste Local

Fizemos a seguinte requisição:

![image](https://user-images.githubusercontent.com/18493760/110029663-81c5b300-7d13-11eb-9825-a4b81ac7f625.png)

E podemos observar pelo log que o a função de sanitização foi devidamente aplicada:

![image](https://user-images.githubusercontent.com/18493760/110029738-9904a080-7d13-11eb-8b0e-25b9e59dcc78.png)

### Teste Staging

O mesmo teste acima foi realizado em staging e os campos foram devidamente sanitizados:

![image](https://user-images.githubusercontent.com/18493760/110120542-f2b0ad80-7d9b-11eb-8b67-e0491849565f.png)

![image](https://user-images.githubusercontent.com/18493760/110120632-0d832200-7d9c-11eb-8e22-3ae562dbe48d.png)


## Checklist

- [x] Associei corretamente a Tarefa do Board ao Pull Request.
- [x] Meu código segue as diretrizes desse projeto.
- [x] Eu revisei meu próprio código.
- [x] Eu comentei meu código em áreas particulares de difícil compreensão.
- [ ] Eu atualizei a documentação de acordo com as mudanças realizadas.
- [x] Meu código não gerou novos warnings.
- [x] Eu adicionei testes que provam que minha correção é efetiva ou que a nova feature funciona.
- [x] Testes novos e existentes passam localmente com minhas alterações. 
- [ ] Testes novos e existentes passam em staging com minhas alterações. 
- [x] Qualquer dependência dessa alteração já foi realizada (deploy, configuração em todos os ambientes, etc).
