### PR TITLE
Fix/gracefully shutdown

### DIFF
--- a/api/middlewares.go
+++ b/api/middlewares.go
@@ -1,14 +1,12 @@
 package api
 
 import (
-	"errors"
 	"net/http"
 	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/mundipagg/boleto-api/bank"
-	"github.com/mundipagg/boleto-api/config"
 	"github.com/mundipagg/boleto-api/log"
 	"github.com/mundipagg/boleto-api/metrics"
 	"github.com/mundipagg/boleto-api/models"
@@ -27,15 +25,6 @@ func returnHeaders() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.Header("Content-Type", "application/json")
 		c.Next()
-	}
-}
-
-func executionController() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		if config.IsRunning() {
-			c.AbortWithError(500, errors.New("a aplicação está sendo finalizada"))
-			return
-		}
 	}
 }
 

--- a/api/mock.go
+++ b/api/mock.go
@@ -10,7 +10,6 @@ func mockInstallApi() *gin.Engine {
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()
 	r.Use(gin.Recovery())
-	r.Use(executionController())
 	Base(r)
 	V1(r)
 	V2(r)

--- a/api/rest.go
+++ b/api/rest.go
@@ -1,17 +1,27 @@
 package api
 
 import (
+	"context"
+	stdlog "log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
 	"github.com/gin-gonic/gin"
 	"github.com/mundipagg/boleto-api/config"
+	"github.com/mundipagg/boleto-api/db"
+	"github.com/mundipagg/boleto-api/log"
 )
 
 //InstallRestAPI "instala" e sobe o servico de rest
 func InstallRestAPI() {
 
+	l := log.CreateLog()
 	gin.SetMode(gin.ReleaseMode)
 	router := gin.New()
 	router.Use(gin.Recovery())
-	router.Use(executionController())
 	useNewRelic(router)
 
 	if config.Get().DevMode && !config.Get().MockMode {
@@ -22,5 +32,41 @@ func InstallRestAPI() {
 	V1(router)
 	V2(router)
 
-	router.Run(config.Get().APIPort)
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, syscall.SIGINT, syscall.SIGTERM)
+
+	server := &http.Server{
+		Addr:    config.Get().APIPort,
+		Handler: router,
+	}
+
+	go func() {
+		err := server.ListenAndServe()
+		if err != nil && err != http.ErrServerClosed {
+			interrupt <- syscall.SIGTERM
+			l.Error(err, "Got an error when trying serve.ListAndServe()")
+			stdlog.Println("err: ", err)
+		}
+	}()
+
+	<-interrupt
+	stdlog.Println("shutdown server")
+
+	// Close DB Connection
+	err := db.CloseConnection()
+	if err != nil {
+		l.Error(err, "Shutdown server with error")
+	} else {
+		l.InfoWithParams("Mongodb connection successfully closed", "Information", nil)
+	}
+
+	// Server Shutdown
+	err = server.Shutdown(context.Background())
+	if err != nil {
+		l.Error(err, "Shutdown server with error")
+	}
+
+	l.InfoWithParams("Shutdown completed", "Information", nil)
+	stdlog.Println("shutdown completed")
+	time.Sleep(10 * time.Second)
 }

--- a/api/rest.go
+++ b/api/rest.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mundipagg/boleto-api/config"
 	"github.com/mundipagg/boleto-api/db"
 	"github.com/mundipagg/boleto-api/log"
+	"github.com/mundipagg/boleto-api/queue"
 )
 
 //InstallRestAPI "instala" e sobe o servico de rest
@@ -55,18 +56,26 @@ func InstallRestAPI() {
 	// Close DB Connection
 	err := db.CloseConnection()
 	if err != nil {
-		l.Error(err, "Shutdown server with error")
+		l.Error(err, "error closing Mongodb connection")
 	} else {
-		l.InfoWithParams("Mongodb connection successfully closed", "Information", nil)
+		l.InfoWithParams("mongodb connection successfully closed", "Information", nil)
+	}
+
+	// Close RabbitMQ Connection
+	err = queue.CloseConnection()
+	if err != nil {
+		l.Error(err, "error closing rabbitmq connection")
+	} else {
+		l.InfoWithParams("rabbitmq connection successfully closed", "Information", nil)
 	}
 
 	// Server Shutdown
 	err = server.Shutdown(context.Background())
 	if err != nil {
-		l.Error(err, "Shutdown server with error")
+		l.Error(err, "shutdown server with error")
 	}
 
-	l.InfoWithParams("Shutdown completed", "Information", nil)
+	l.InfoWithParams("shutdown completed", "Information", nil)
 	stdlog.Println("shutdown completed")
 	time.Sleep(10 * time.Second)
 }

--- a/db/mongodb.go
+++ b/db/mongodb.go
@@ -274,3 +274,10 @@ func ping() error {
 
 	return nil
 }
+
+func CloseConnection() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	return conn.Disconnect(ctx)
+}

--- a/main.go
+++ b/main.go
@@ -5,14 +5,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/signal"
 	"runtime"
 	"strconv"
-	"syscall"
 
 	"github.com/mundipagg/boleto-api/app"
 	"github.com/mundipagg/boleto-api/config"
-	"github.com/mundipagg/boleto-api/log"
 )
 
 var (
@@ -27,19 +24,6 @@ var (
 
 func init() {
 	createPIDfile()
-	// Configure signal handler
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
-	signal.Notify(c, syscall.SIGTERM)
-	go handleSignal(c)
-}
-
-func handleSignal(c chan os.Signal) {
-	<-c
-	config.Stop()
-	log.Info("Quiting BoletoApi")
-	fmt.Println("Done")
-	os.Exit(1)
 }
 
 func createPIDfile() {

--- a/queue/queueOperation.go
+++ b/queue/queueOperation.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"fmt"
+
 	"github.com/mundipagg/boleto-api/log"
 
 	"github.com/streadway/amqp"
@@ -24,6 +25,15 @@ func OpenConnection() error {
 // GetConnectionReadOnly Obtém conexão de leitura com RabbitMQ
 func GetConnection() *amqp.Connection {
 	return conn
+}
+
+// CloseConnection close RabbitMQ connection
+func CloseConnection() error {
+	if conn == nil {
+		return nil
+	}
+
+	return conn.Close()
 }
 
 func failOnError(err error, title string, op string, msg ...string) {


### PR DESCRIPTION
# Descrição

### Tarefa [BPROC-193](https://mundipagg.atlassian.net/browse/BPROC-193) 

A partir dessa PR, a aplicação passa a tratar o sinal SIGTERM, encerrando o uso dos seguintes recursos:
- MongoDB;
- RabbitMQ;

A aplicação também vai concluir as requests que recebeu antes do SIGTERM e não receberá novas.

### Tipos de alterações

- [ ] Correção de bug 
- [x] Nova feature 
- [ ] Alteração ou remoção de funcionalidade existente
- [ ] Atualização de documentação

## Testes

Para testar, subi a aplicação localmente e após efetuar uma requisição, realizei o "ctrl + c" no processo para que a aplicação recebesse o SIGTERM.
Como resultado, minha request foi finalizada com sucesso eos logs dos recursos sendo fechados foram gerados:
Console da aplicação:
![image](https://user-images.githubusercontent.com/10201627/128237411-bbcc55df-53a9-4c5e-8756-edd96734b4de.png)
Request finalizada com sucesso:
![image](https://user-images.githubusercontent.com/10201627/128237545-9c00dd43-302d-475b-b10a-26f860c4911e.png)
Logs gerados:
![image](https://user-images.githubusercontent.com/10201627/128237672-ee319169-d2b2-4e89-99b2-8009270ba2ab.png)

### Testes Unitários
![image](https://user-images.githubusercontent.com/10201627/128238287-bbabf586-92e1-4012-b052-08512f379610.png)

## Checklist

- [x] Associei corretamente a Tarefa do Board ao Pull Request.
- [x] Meu código segue as diretrizes desse projeto.
- [x] Eu revisei meu próprio código.
- [x] Eu comentei meu código em áreas particulares de difícil compreensão.
- [x] Eu atualizei a documentação de acordo com as mudanças realizadas.
- [x] Meu código não gerou novos warnings.
- [x] Eu adicionei testes que provam que minha correção é efetiva ou que a nova feature funciona.
- [x] Testes novos e existentes passam localmente com minhas alterações. 
- [ ] Testes novos e existentes passam em staging com minhas alterações. 
- [ ] Qualquer dependência dessa alteração já foi realizada (deploy, configuração em todos os ambientes, etc).
