### PR TITLE
[BPROC-207] Adiciona issue na geracao de jwt da stone

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -73,7 +73,7 @@ func (l *Log) Request(content interface{}, url string, headers map[string]string
 }
 
 //Response loga o response para algum banco
-func (l *Log) Response(content interface{}, url string) {
+func (l *Log) Response(content interface{}, url string, params LogEntry) {
 	if config.Get().DisableLog {
 		return
 	}
@@ -84,6 +84,9 @@ func (l *Log) Response(content interface{}, url string) {
 
 		props := l.defaultProperties("Response", content)
 		props["URL"] = url
+		for k, v := range params {
+			props[k] = v
+		}
 
 		l.logger.Info(msg, props)
 	})()

--- a/stone/jwt.go
+++ b/stone/jwt.go
@@ -37,6 +37,7 @@ func generateJWT() (string, error) {
 	atClaims["clientId"] = config.Get().StoneClientID
 	atClaims["iat"] = now.Unix()
 	atClaims["jti"] = generateJTIFromTime(now)
+	atClaims["iss"] = config.Get().StoneClientID
 
 	at := jwt.NewWithClaims(jwt.SigningMethodRS256, atClaims)
 

--- a/stone/stone.go
+++ b/stone/stone.go
@@ -51,6 +51,7 @@ func (b bankStone) ProcessBoleto(boleto *models.BoletoRequest) (models.BoletoRes
 
 func (b bankStone) RegisterBoleto(boleto *models.BoletoRequest) (models.BoletoResponse, error) {
 	var response string
+	var header string
 	var status int
 	var err error
 
@@ -62,13 +63,22 @@ func (b bankStone) RegisterBoleto(boleto *models.BoletoRequest) (models.BoletoRe
 	b.log.Request(body, stoneURL, head)
 
 	duration := util.Duration(func() {
-		response, status, err = util.Post(stoneURL, body, config.Get().TimeoutRegister, head)
+		response, header, status, err = util.PostReponseWithHeader(stoneURL, body, config.Get().TimeoutRegister, head)
 	})
 	metrics.PushTimingMetric("stone-register-boleto-time", duration.Seconds())
 
-	b.log.Response(response, stoneURL)
+	params := getLogResponseProperties(header)
+
+	b.log.Response(response, stoneURL, params)
 
 	return mapStoneResponse(boleto, response, status, err), nil
+}
+
+func getLogResponseProperties(header string) map[string]interface{} {
+	m := make(map[string]interface{})
+	m["Header"] = header
+
+	return m
 }
 
 func mapStoneResponse(request *models.BoletoRequest, response string, status int, httpErr error) models.BoletoResponse {

--- a/util/connectors.go
+++ b/util/connectors.go
@@ -39,7 +39,7 @@ func LogConector(e *flow.ExchangeMessage, u flow.URI, params ...interface{}) err
 			l.Request(b, u.GetOption("url"), e.GetHeaderMap())
 		}
 		if u.GetOption("type") == "response" {
-			l.Response(b, u.GetOption("url"))
+			l.Response(b, u.GetOption("url"), nil)
 		}
 	}
 	return nil

--- a/util/http.go
+++ b/util/http.go
@@ -114,9 +114,6 @@ func PostReponseWithHeader(url, body, timeout string, header map[string]string) 
 	return doRequest("POST", url, body, timeout, header)
 }
 
-//Get faz um requisição GET para uma URL e retorna o response, status e erro
-func Get(url, body, timeout string, header map[string]string) (string, int, error) {
-	return doRequest("GET", url, body, timeout, header)
 //Post faz um requisição POST para uma URL e retorna o response, status e erro
 func Post(url, body, timeout string, header map[string]string) (string, int, error) {
 	resp, _, st, err := doRequest("POST", url, body, timeout, header)

--- a/util/http.go
+++ b/util/http.go
@@ -88,7 +88,7 @@ func (hc *HTTPClient) PostFormURLEncoded(endpoint string, params map[string]stri
 	}
 
 	respByte, err := ioutil.ReadAll(resp.Body)
-	log.Response(string(respByte), endpoint)
+	log.Response(string(respByte), endpoint, nil)
 
 	return respByte, err
 }
@@ -110,16 +110,20 @@ func DefaultHTTPClient() *http.Client {
 }
 
 //Post faz um requisição POST para uma URL e retorna o response, status e erro
-func Post(url, body, timeout string, header map[string]string) (string, int, error) {
+func PostReponseWithHeader(url, body, timeout string, header map[string]string) (string, string, int, error) {
 	return doRequest("POST", url, body, timeout, header)
 }
 
 //Get faz um requisição GET para uma URL e retorna o response, status e erro
 func Get(url, body, timeout string, header map[string]string) (string, int, error) {
 	return doRequest("GET", url, body, timeout, header)
+//Post faz um requisição POST para uma URL e retorna o response, status e erro
+func Post(url, body, timeout string, header map[string]string) (string, int, error) {
+	resp, _, st, err := doRequest("POST", url, body, timeout, header)
+	return resp, st, err
 }
 
-func doRequest(method, url, body, timeout string, header map[string]string) (string, int, error) {
+func doRequest(method, url, body, timeout string, header map[string]string) (string, string, int, error) {
 	t := GetDurationTimeoutRequest(timeout) * time.Second
 
 	ctx, cls := context.WithTimeout(context.Background(), t)
@@ -131,7 +135,7 @@ func doRequest(method, url, body, timeout string, header map[string]string) (str
 
 	req, err := http.NewRequestWithContext(ctx, method, url, message)
 	if err != nil {
-		return "", http.StatusInternalServerError, err
+		return "", "", http.StatusInternalServerError, err
 	}
 	if header != nil {
 		for k, v := range header {
@@ -140,15 +144,17 @@ func doRequest(method, url, body, timeout string, header map[string]string) (str
 	}
 	resp, errResp := client.Do(req)
 	if errResp != nil {
-		return "", 0, errResp
+		return "", "", 0, errResp
 	}
 	defer resp.Body.Close()
+	respHeader := fmt.Sprintf("%v", resp.Header)
+
 	data, errResponse := ioutil.ReadAll(resp.Body)
 	if errResponse != nil {
-		return "", resp.StatusCode, errResponse
+		return "", respHeader, resp.StatusCode, errResponse
 	}
 	sData := string(data)
-	return sData, resp.StatusCode, nil
+	return sData, respHeader, resp.StatusCode, nil
 }
 
 // BuildTLSTransport creates a TLS Client Transport from crt, ca and key files


### PR DESCRIPTION
# Descrição

### Tarefa [BPROC-207](https://mundipagg.atlassian.net/secure/RapidBoard.jspa?rapidView=346&projectKey=BPROC&modal=detail&selectedIssue=BPROC-207) 

Essa nova implementação tem como objetivo adicionar o campo ISS ao gerar o token JWT para autenticação na Stone, já que esse campo se tornou obrigatório conforme [documentação Stone.](https://docs.openbank.stone.com.br/docs/guias/token-de-acesso/#especifica%C3%A7%C3%B5es-do-jwt-para-realizar-autentica%C3%A7%C3%A3o)

Outra necessidade suprida nessa implementação é a adição do header no log de response da Stone, alteração necessária para que seja possível realizar a homologação com o banco, em virtude da necessidade de inspecionar o header ``x-request-id`

### Tipos de alterações

- [ ] Correção de bug 
- [x] Nova feature 
- [ ] Alteração ou remoção de funcionalidade existente
- [ ] Atualização de documentação

## Testes

### Teste Local da adição do ISS

![image](https://user-images.githubusercontent.com/62444301/131915603-64b5d3ca-7f35-4369-a696-91db110e271e.png)
![image](https://user-images.githubusercontent.com/62444301/131915817-dafec718-beb3-4f7f-b6f2-290a12d36cda.png)


### Teste Staging da adição do ISS

Inicialmente foi realizado o request em staging com uma versão que não continha o novo campo ISS, depois fizemos o deploy da nova versão e o request funcionou corretamente.

![image](https://user-images.githubusercontent.com/62444301/131916125-06e3b735-0d23-4753-b566-abdaa7551ff1.png)

![image](https://user-images.githubusercontent.com/62444301/131916335-7b57d5eb-d91b-4e5c-a41d-f49e35eaf015.png)

Para confirmar que tudo continuava funcionando, foi realizado os request na rota V1 e V2 em todos os bancos. Nesse cenário havia um problema no ambiente de testes da caixa.

![image](https://user-images.githubusercontent.com/62444301/131916872-bd22a099-353e-4ad8-84fb-b10e8d39bd49.png)

### Teste Local da adição do header no log Stone

![image](https://user-images.githubusercontent.com/62444301/132065098-fb5e6f08-eab9-4b3a-88b7-b6b369813ff3.png)

### Teste em Staging da adição do header no log Stone

Log do Seq onde o teste foi realizado em staging e o request tem os parâmetros corretos.

![image](https://user-images.githubusercontent.com/62444301/132065257-2ca7c609-9c50-4f2b-b36c-738e545af12a.png)

Log do Seq onde o teste foi realizado em staging e o request tem algum parâmetro errado.

![image](https://user-images.githubusercontent.com/62444301/132065370-407a3c58-70dc-49ec-811e-bbd63fcb040a.png)

Todos os testes foram realizados no postman e todos continuaram passando corretamente após a implementação.

![image](https://user-images.githubusercontent.com/62444301/132065598-612041e6-a06b-4579-815c-46040165e841.png)

## Checklist

- [x] Associei corretamente a Tarefa do Board ao Pull Request.
- [x] Meu código segue as diretrizes desse projeto.
- [x] Eu revisei meu próprio código.
- [ ] Eu comentei meu código em áreas particulares de difícil compreensão.
- [ ] Eu atualizei a documentação de acordo com as mudanças realizadas.
- [x] Meu código não gerou novos warnings.
- [ ] Eu adicionei testes que provam que minha correção é efetiva ou que a nova feature funciona.
- [x] Testes novos e existentes passam localmente com minhas alterações. 
- [x] Testes novos e existentes passam em staging com minhas alterações. 
- [ ] Qualquer dependência dessa alteração já foi realizada (deploy, configuração em todos os ambientes, etc).
