### PR TITLE
[BPROC-285] Melhoria de logs - Falhas de Segurança

### DIFF
--- a/util/http.go
+++ b/util/http.go
@@ -394,7 +394,11 @@ func PostTLSWithHeader(url, body, timeout string, header map[string]string, tran
 func HeaderToMap(h http.Header) map[string]string {
 	m := make(map[string]string)
 	for k, v := range h {
-		m[k] = v[0]
+		if k == "Authorization" {
+			m[k] = "***"
+		} else {
+			m[k] = v[0]
+		}
 	}
 	return m
 }

--- a/util/http.go
+++ b/util/http.go
@@ -391,14 +391,14 @@ func PostTLSWithHeader(url, body, timeout string, header map[string]string, tran
 }
 
 //HeaderToMap converte um http Header para um dicionário string -> string
-func HeaderToMap(h http.Header) map[string]string {
-	m := make(map[string]string)
-	for k, v := range h {
-		if k == "Authorization" {
-			m[k] = "***"
+func HeaderToMap(header http.Header) map[string]string {
+	headerMap := make(map[string]string)
+	for key, value := range header {
+		if key == "Authorization" {
+			headerMap[key] = "***"
 		} else {
-			m[k] = v[0]
+			headerMap[key] = value[0]
 		}
 	}
-	return m
+	return headerMap
 }

--- a/util/http_test.go
+++ b/util/http_test.go
@@ -8,31 +8,31 @@ import (
 )
 
 func TestHeaderToMap(t *testing.T) {
-	h := getHeader()
+	header := getHeader()
 
-	result := HeaderToMap(h)
+	result := HeaderToMap(header)
 
-	assert.Equal(t, len(h), len(result))
+	assert.Equal(t, len(header), len(result))
 	assert.Equal(t, result["Authorization"], "***")
 }
 
 func BenchmarkHeaderToMap(b *testing.B) {
-	h := getHeader()
+	header := getHeader()
 	for n := 0; n < b.N; n++ {
-		HeaderToMap(h)
+		HeaderToMap(header)
 	}
 }
 
 func getHeader() http.Header {
-	h := make(http.Header)
-	h.Add("Authorization", "Basic NWVjNWI5zBkOmFiNjE3YzM4LTliNzAtNGE1OS1hMzhmLTMzMTU0ZmFiMDEwYw==")
-	h.Add("PostmanToken", "7dc1c2cd-4a22-49ed-85f8-f081e3cb25dc")
-	h.Add("AcceptEncoding", "gzip, deflate, br")
-	h.Add("ContentLength", "1933")
-	h.Add("ContentType", "application/json")
-	h.Add("Connection", "no-cache")
-	h.Add("CacheControl", "keep-alive")
-	h.Add("Accept", "*/*")
-	h.Add("UserAgent", "PostmanRuntime/7.28.4")
-	return h
+	header := make(http.Header)
+	header.Add("Authorization", "Basic NWVjNWI5zBkOmFiNjE3YzM4LTliNzAtNGE1OS1hMzhmLTMzMTU0ZmFiMDEwYw==")
+	header.Add("PostmanToken", "7dc1c2cd-4a22-49ed-85f8-f081e3cb25dc")
+	header.Add("AcceptEncoding", "gzip, deflate, br")
+	header.Add("ContentLength", "1933")
+	header.Add("ContentType", "application/json")
+	header.Add("Connection", "no-cache")
+	header.Add("CacheControl", "keep-alive")
+	header.Add("Accept", "*/*")
+	header.Add("UserAgent", "PostmanRuntime/7.28.4")
+	return header
 }

--- a/util/http_test.go
+++ b/util/http_test.go
@@ -1,0 +1,38 @@
+package util
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHeaderToMap(t *testing.T) {
+	h := getHeader()
+
+	result := HeaderToMap(h)
+
+	assert.Equal(t, len(h), len(result))
+	assert.Equal(t, result["Authorization"], "***")
+}
+
+func BenchmarkHeaderToMap(b *testing.B) {
+	h := getHeader()
+	for n := 0; n < b.N; n++ {
+		HeaderToMap(h)
+	}
+}
+
+func getHeader() http.Header {
+	h := make(http.Header)
+	h.Add("Authorization", "Basic NWVjNWI5zBkOmFiNjE3YzM4LTliNzAtNGE1OS1hMzhmLTMzMTU0ZmFiMDEwYw==")
+	h.Add("PostmanToken", "7dc1c2cd-4a22-49ed-85f8-f081e3cb25dc")
+	h.Add("AcceptEncoding", "gzip, deflate, br")
+	h.Add("ContentLength", "1933")
+	h.Add("ContentType", "application/json")
+	h.Add("Connection", "no-cache")
+	h.Add("CacheControl", "keep-alive")
+	h.Add("Accept", "*/*")
+	h.Add("UserAgent", "PostmanRuntime/7.28.4")
+	return h
+}


### PR DESCRIPTION
# Descrição

### Tarefa [BPROC-285](https://mundipagg.atlassian.net/browse/BPROC-285) 

O objetivo desta tarefa é mascarar o nó de **Authorization** que atualmente é enviado no header da requisição com as credenciais do usuário da aplicação.

### Tipos de alterações

- [x] Correção de bug 
- [ ] Nova feature 
- [ ] Alteração ou remoção de funcionalidade existente
- [ ] Atualização de documentação

## Testes

### Teste Local

Após a correção passamos a logar o campo devidamente mascarado:

![image](https://user-images.githubusercontent.com/18493760/142058225-313d3cff-3180-4507-9852-d9a2d93c2b3b.png)

### Teste Staging

Após a correção passamos a logar o campo devidamente mascarado:

![image](https://user-images.githubusercontent.com/18493760/142060101-2ab3688d-5cf2-48ec-8252-c8420bef08f2.png)

Todos os testes foram executados com sucesso:

![image](https://user-images.githubusercontent.com/18493760/142060244-adc7aa88-9468-45dd-85e8-c8443e70e143.png)

## Checklist

- [x] Associei corretamente a Tarefa do Board ao Pull Request.
- [x] Meu código segue as diretrizes desse projeto.
- [x] Eu revisei meu próprio código.
- [x] Eu comentei meu código em áreas particulares de difícil compreensão.
- [x] Eu atualizei a documentação de acordo com as mudanças realizadas.
- [x] Meu código não gerou novos warnings.
- [ ] Eu adicionei testes que provam que minha correção é efetiva ou que a nova feature funciona.
- [x] Testes novos e existentes passam localmente com minhas alterações. 
- [ ] Testes novos e existentes passam em staging com minhas alterações. 
- [x] Qualquer dependência dessa alteração já foi realizada (deploy, configuração em todos os ambientes, etc).
