### PR TITLE
[BPROC-294] Adiciona zeros ao NossoNumero JPMorgan

### DIFF
--- a/bank/services/jpmorgan/contracts.go
+++ b/bank/services/jpmorgan/contracts.go
@@ -76,7 +76,7 @@ const templateAPI = `
     {{else}}
         "DigitableLine": "{{fmtDigitableLine (trim .digitableLine)}}",
         "BarCodeNumber": "{{trim .barCodeNumber}}",
-        "OurNumber": "{{.ourNumber}}"
+        "OurNumber": "{{padLeft .ourNumber "0" 12}}"
     {{end}}
 }
 `

--- a/bank/services/jpmorgan/jpmorgan.go
+++ b/bank/services/jpmorgan/jpmorgan.go
@@ -237,5 +237,5 @@ func timeoutMessage(err error) string {
 }
 
 func hasOurNumberFail(response *models.BoletoResponse) bool {
-	return !response.HasErrors() && response.OurNumber == ""
+	return !response.HasErrors() && (response.OurNumber == "" || response.OurNumber == "000000000000")
 }

--- a/bank/services/jpmorgan/jpmorgan_test.go
+++ b/bank/services/jpmorgan/jpmorgan_test.go
@@ -34,6 +34,22 @@ func Test_ProcessBoleto_WhenServiceRespondsSuccessfully_ShouldHasSuccessfulBolet
 	output, err := bank.ProcessBoleto(input)
 
 	assert.Nil(t, err, "Não deve haver um erro")
+	assert.Equal(t, 12, len(output.OurNumber))
+	assert.Equal(t, "123456789012", output.OurNumber)
+	test.AssertProcessBoletoWithSuccess(t, output)
+}
+
+func Test_ProcessBoleto_WhenServiceRespondsWithShortOurNUmber_ShouldHasPadZerosAndSuccessfulBoletoResponse(t *testing.T) {
+	mock.StartMockService("9102")
+	certificate.LoadMockCertificates()
+	input := newStubBoletoRequestJPMorgan().WithAmountInCents(211).Build()
+	bank, _ := New()
+
+	output, err := bank.ProcessBoleto(input)
+
+	assert.Nil(t, err, "Não deve haver um erro")
+	assert.Equal(t, 12, len(output.OurNumber))
+	assert.Equal(t, "000000123456", output.OurNumber)
 	test.AssertProcessBoletoWithSuccess(t, output)
 }
 
@@ -45,7 +61,7 @@ func Test_ProcessBoleto_WhenServiceRespondsUnsuccessful_ShouldHasErrorResponse(t
 	for _, fact := range boletoResponseFailParameters {
 		request := fact.Input.(*models.BoletoRequest)
 		response, err := bank.ProcessBoleto(request)
-		assert.Nil(t, err, "Não deve haver um erro")
+		assert.Nil(t, err, "Não deve haver um erro fora do objeto de response")
 
 		test.AssertProcessBoletoFailed(t, response)
 		assert.Equal(t, fact.Expected.(models.ErrorResponse).Code, response.Errors[0].Code)

--- a/mock/jpmorgan.go
+++ b/mock/jpmorgan.go
@@ -58,7 +58,62 @@ const successResponseJp = `
 	   },
 	   "numCodBarras":"37691877200000002000098000600016400000504858",
 	   "linhaDigitavel":"37690098080060001640600005048582187720000000200",
-	   "identdNossoNum":"504858"
+	   "identdNossoNum":"123456789012"
+	}
+ }
+`
+
+const successResponseJpShortOurNumber = `
+{
+	"resposta":{
+	   "clienteBeneficiario":{
+		  "codBanco":376,
+		  "codAgencia":98,
+		  "codContaCorrente":6000164,
+		  "tpPessoaBenfcrioOr":2,
+		  "cnpjCpfBenfcrioOr":"33172537000198",
+		  "codCartTit":1,
+		  "txtInfCliCed":"TEST PAGARME"
+	   },
+	   "titulo":{
+		  "numDocTit":"1001",
+		  "dtVencTit":"2021-10-13",
+		  "vlrTit":2,
+		  "codEspTit":2,
+		  "dtEmsTit":"2021-10-08",
+		  "vlrAbattTit":0,
+		  "tpCodPrott":3,
+		  "qtdDiaPrott":0,
+		  "codMoedaCnab":9
+	   },
+	   "juros":{
+		  "codJurosTit":2,
+		  "vlrPercJurosTit":7,
+		  "dtJurosTit":"2021-10-14"
+	   },
+	   "descontos":{
+		  "codDesctTit":0,
+		  "dtDesctTit":null,
+		  "vlrPercDesctTit":0
+	   },
+	   "sacadoOuPagador":{
+		  "tpPessoaPagdr":1,
+		  "cnpjCpfPagdr":"37303489819",
+		  "nomRzSocPagdr":"Nome do Comprador Cliente",
+		  "logradPagdr":"Logradouro",
+		  "bairroPagdr":"Bairro",
+		  "cepPagdr":"15050466",
+		  "cidPagdr":"Cidade",
+		  "ufPagdr":"SP"
+	   },
+	   "multa":{
+		  "dtMultaTit":null,
+		  "codMultaTit":3,
+		  "vlrPercMultaTit":0
+	   },
+	   "numCodBarras":"37691877200000002000098000600016400000504858",
+	   "linhaDigitavel":"37690098080060001640600005048582187720000000200",
+	   "identdNossoNum":"123456"
 	}
  }
 `
@@ -210,6 +265,8 @@ func registerJpMorgan(c *gin.Context) {
 		c.Data(200, contentApplication, []byte(successResponseJp))
 	} else if strings.Contains(json, `"vlrTit": 2.05,`) {
 		c.Data(200, "application/xml", []byte(successResponseJpWithoutOurNumber))
+	} else if strings.Contains(json, `"vlrTit": 2.11,`) {
+		c.Data(200, "application/xml", []byte(successResponseJpShortOurNumber))
 	} else if strings.Contains(json, `"vlrTit": 2.01,`) {
 		c.Data(500, "application/xml", []byte(withoutCert))
 	} else if strings.Contains(json, `"vlrTit": 2.02,`) {


### PR DESCRIPTION
# Descrição

### Tarefa [BPROC-294](https://mundipagg.atlassian.net/browse/BPROC-294)

Adiciona zeros a esquerda do NossoNumero retornado pela JPMorgan. 

### Tipos de alterações

- [x] Correção de bug 
- [ ] Nova feature 
- [ ] Alteração ou remoção de funcionalidade existente
- [ ] Atualização de documentação

## Testes

Simulamos 02 cenários: um no qual o NossoNumero contém menos de 12 caracteres e outro no qual contém exatamente 12.

CENÁRIO 1 - Registro de Boleto com NossoNumero inferior a 12 caracteres

Simulando a resposta com menos de 12 caracteres podemos verificar que o NossoNumero retornado é complementado com zeros à esquerda até o total de 12 caracteres:

![image](https://user-images.githubusercontent.com/18493760/143259712-d115bebb-6c8f-4cae-8f93-d2f8b36bfc96.png)

![image](https://user-images.githubusercontent.com/18493760/143259726-96258dc7-ef4e-4cd7-8638-f4f714a1cb3a.png)

CENÁRIO 2 - Registro de Boleto com NossoNumero com 12 caracteres

Simulando a resposta com 12 caracteres podemos verificar que o NossoNumero retornado é exatamente o retornado pelo banco:

![image](https://user-images.githubusercontent.com/18493760/143259334-28a86504-ee35-428c-9328-3f589768f024.png)

![image](https://user-images.githubusercontent.com/18493760/143259315-9264fbd2-9f8d-4840-96ad-d489bd769bcf.png)

## Checklist

- [x] Associei corretamente a Tarefa do Board ao Pull Request.
- [x] Meu código segue as diretrizes desse projeto.
- [x] Eu revisei meu próprio código.
- [x] Eu comentei meu código em áreas particulares de difícil compreensão.
- [x] Eu atualizei a documentação de acordo com as mudanças realizadas.
- [x] Meu código não gerou novos warnings.
- [x] Eu adicionei testes que provam que minha correção é efetiva ou que a nova feature funciona.
- [x] Testes novos e existentes passam localmente com minhas alterações. 
- [x] Testes novos e existentes passam em staging com minhas alterações. 
- [x] Qualquer dependência dessa alteração já foi realizada (deploy, configuração em todos os ambientes, etc).
