### PR TITLE
[BPROC-368] - implements interest and fine to provider Caixa

### DIFF
--- a/caixa/caixa.go
+++ b/caixa/caixa.go
@@ -37,6 +37,8 @@ func New() bankCaixa {
 	b.validate.Push(caixaValidateAgency)
 	b.validate.Push(validadeOurNumber)
 	b.validate.Push(caixaValidateBoletoType)
+	b.validate.Push(caixaValidateInterest)
+	b.validate.Push(caixaValidateFine)
 	return b
 }
 

--- a/caixa/stub.go
+++ b/caixa/stub.go
@@ -79,3 +79,29 @@ func (s *stubBoletoRequestCaixa) WithFlexRules() *stubBoletoRequestCaixa {
 	}
 	return s
 }
+
+func (s *stubBoletoRequestCaixa) WithFine(daysAfterExpirationDate uint, amountInCents uint64, percentageOnTotal float64) *stubBoletoRequestCaixa {
+	if !s.Title.HasFees() {
+		s.Title.Fees = &models.Fees{}
+	}
+
+	s.Title.Fees.Fine = &models.Fine{
+		DaysAfterExpirationDate: daysAfterExpirationDate,
+		AmountInCents:           amountInCents,
+		PercentageOnTotal:       percentageOnTotal,
+	}
+	return s
+}
+
+func (s *stubBoletoRequestCaixa) WithInterest(daysAfterExpirationDate uint, amountPerDayInCents uint64, percentagePerMonth float64) *stubBoletoRequestCaixa {
+	if !s.Title.HasFees() {
+		s.Title.Fees = &models.Fees{}
+	}
+
+	s.Title.Fees.Interest = &models.Interest{
+		DaysAfterExpirationDate: daysAfterExpirationDate,
+		AmountPerDayInCents:     amountPerDayInCents,
+		PercentagePerMonth:      percentagePerMonth,
+	}
+	return s
+}

--- a/caixa/validations.go
+++ b/caixa/validations.go
@@ -86,3 +86,33 @@ func caixaValidateBoletoType(b interface{}) error {
 		return validations.InvalidType(t)
 	}
 }
+
+func caixaValidateInterest(b interface{}) error {
+	switch t := b.(type) {
+	case *models.BoletoRequest:
+		if t.Title.Fees.HasInterest() {
+			if err := t.Title.Fees.Interest.Validate(); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	default:
+		return validations.InvalidType(t)
+	}
+}
+
+func caixaValidateFine(b interface{}) error {
+	switch t := b.(type) {
+	case *models.BoletoRequest:
+		if t.Title.Fees.HasFine() {
+			if err := t.Title.Fees.Fine.Validate(); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	default:
+		return validations.InvalidType(t)
+	}
+}

--- a/models/fees.go
+++ b/models/fees.go
@@ -1,11 +1,16 @@
 package models
 
-const (
-	Percentual = "percentual"
-	Nominal    = "nominal"
-)
-
 type Fees struct {
-	Fine     Fine     `json:"fine,omitempty"`
-	Interest Interest `json:"interest,omitempty"`
+	Fine     *Fine     `json:"fine,omitempty"`
+	Interest *Interest `json:"interest,omitempty"`
+}
+
+//HasFine Verifica se o nó de fine está preenchido
+func (f *Fees) HasFine() bool {
+	return f != nil && f.Fine != nil
+}
+
+//HasInterest Verifica se o nó de interest está preenchido
+func (f *Fees) HasInterest() bool {
+	return f != nil && f.Interest != nil
 }

--- a/models/fine_test.go
+++ b/models/fine_test.go
@@ -8,38 +8,123 @@ import (
 )
 
 type testFineParameter struct {
-	Input         interface{}
-	Expected      interface{}
-	AmountInCents interface{}
+	Line     interface{}
+	Input    interface{}
+	Expected interface{}
 }
 
-var fineParameters = []testFineParameter{
-	{Input: Fine{Type: "Percentual", Days: 0, Rate: 0.010}, AmountInCents: 0, Expected: true},
-	{Input: Fine{Type: "Percentual ", Days: 0, Rate: 0.010}, AmountInCents: 0, Expected: false},
-	{Input: Fine{Type: "PERCENTUAL", Days: 0, Rate: 0.010}, AmountInCents: 0, Expected: true},
-	{Input: Fine{Type: "pErCeNtUaL", Days: 0, Rate: 0.010}, AmountInCents: 0, Expected: true},
-	{Input: Fine{Type: "Porcentagem", Days: 0, Rate: 0.010}, AmountInCents: 0, Expected: false},
-	{Input: Fine{Type: "Percentual", Days: -1, Rate: 0.010}, AmountInCents: 0, Expected: false},
-	{Input: Fine{Type: "Percentual", Days: 0, Rate: 0.011}, AmountInCents: 0, Expected: false},
-	{Input: Fine{Type: "Percentual", Days: 0, Rate: 0.0101}, AmountInCents: 0, Expected: false},
-	{Input: Fine{Type: "Percentual", Days: 0, Rate: 0.01001}, AmountInCents: 0, Expected: false},
-	{Input: Fine{Type: "Percentual", Days: 0, Rate: 0.010001}, AmountInCents: 0, Expected: false},
-	{Input: Fine{Type: "Nominal", Days: 0, Rate: 1.00}, AmountInCents: 100, Expected: true},
-	{Input: Fine{Type: "NOMINAL", Days: 0, Rate: 1.00}, AmountInCents: 100, Expected: true},
-	{Input: Fine{Type: "nOmInAl", Days: 0, Rate: 1.00}, AmountInCents: 100, Expected: true},
-	{Input: Fine{Type: "Absoluto", Days: 0, Rate: 1.00}, AmountInCents: 100, Expected: false},
-	{Input: Fine{Type: "Nominal", Days: 0, Rate: 2.00}, AmountInCents: 100, Expected: false},
-	{Input: Fine{Type: "Nominal", Days: 0, Rate: 2.00}, AmountInCents: 0, Expected: false},
+var hasFineParameters = []testFineParameter{
+	{Line: 4, Input: Fine{DaysAfterExpirationDate: 1, AmountInCents: 1, PercentageOnTotal: 0}, Expected: true},
+	{Line: 5, Input: Fine{DaysAfterExpirationDate: 1, AmountInCents: 0, PercentageOnTotal: 1.20}, Expected: true},
+	{Line: 6, Input: Fine{DaysAfterExpirationDate: 1, AmountInCents: 200, PercentageOnTotal: 3}, Expected: true},
 }
 
-func TestFine_IsValid(t *testing.T) {
-	i := 1
-	for _, fact := range fineParameters {
+var hasAmountInCentsParameters = []testFineParameter{
+	{Line: 1, Input: Fine{AmountInCents: 0}, Expected: false},
+	{Line: 2, Input: Fine{AmountInCents: 1}, Expected: true},
+	{Line: 3, Input: Fine{AmountInCents: 20034}, Expected: true},
+}
+
+var validateFineParameters = []testFineParameter{
+	{Line: 1, Input: Fine{DaysAfterExpirationDate: 1, AmountInCents: 0, PercentageOnTotal: 0}, Expected: false},
+	{Line: 2, Input: Fine{DaysAfterExpirationDate: 1, AmountInCents: 1, PercentageOnTotal: 0}, Expected: true},
+	{Line: 3, Input: Fine{DaysAfterExpirationDate: 1, AmountInCents: 0, PercentageOnTotal: 1}, Expected: true},
+	{Line: 4, Input: Fine{DaysAfterExpirationDate: 1, AmountInCents: 1, PercentageOnTotal: 1}, Expected: false},
+	{Line: 5, Input: Fine{DaysAfterExpirationDate: 1, PercentageOnTotal: -1}, Expected: false},
+	{Line: 6, Input: Fine{DaysAfterExpirationDate: 1, PercentageOnTotal: -2.34}, Expected: false},
+	{Line: 7, Input: Fine{DaysAfterExpirationDate: 1, PercentageOnTotal: 0}, Expected: false},
+	{Line: 8, Input: Fine{DaysAfterExpirationDate: 1, PercentageOnTotal: 0.0}, Expected: false},
+	{Line: 9, Input: Fine{DaysAfterExpirationDate: 1, PercentageOnTotal: 1}, Expected: true},
+	{Line: 10, Input: Fine{DaysAfterExpirationDate: 1, PercentageOnTotal: 2.23}, Expected: true},
+	{Line: 11, Input: Fine{DaysAfterExpirationDate: 0, AmountInCents: 0, PercentageOnTotal: 0}, Expected: false},
+	{Line: 12, Input: Fine{DaysAfterExpirationDate: 0, AmountInCents: 1, PercentageOnTotal: 0}, Expected: false},
+	{Line: 13, Input: Fine{DaysAfterExpirationDate: 0, AmountInCents: 0, PercentageOnTotal: 1.2}, Expected: false},
+	{Line: 14, Input: Fine{DaysAfterExpirationDate: 1, AmountInCents: 1, PercentageOnTotal: 0.0}, Expected: true},
+	{Line: 15, Input: Fine{DaysAfterExpirationDate: 1, AmountInCents: 0, PercentageOnTotal: 1.2}, Expected: true},
+	{Line: 16, Input: Fine{DaysAfterExpirationDate: 2, AmountInCents: 0, PercentageOnTotal: 1.2}, Expected: true},
+}
+
+var hasExclusiveRateValuesFineParameters = []testFineParameter{
+	{Line: 1, Input: Fine{AmountInCents: 0, PercentageOnTotal: 0}, Expected: false},
+	{Line: 2, Input: Fine{AmountInCents: 1, PercentageOnTotal: 0}, Expected: true},
+	{Line: 3, Input: Fine{AmountInCents: 0, PercentageOnTotal: 1}, Expected: true},
+	{Line: 4, Input: Fine{AmountInCents: 1, PercentageOnTotal: 1}, Expected: false},
+}
+
+var hasPercentageOnTotalParameters = []testFineParameter{
+	{Line: 1, Input: Fine{PercentageOnTotal: -1}, Expected: false},
+	{Line: 2, Input: Fine{PercentageOnTotal: -2.34}, Expected: false},
+	{Line: 3, Input: Fine{PercentageOnTotal: 0}, Expected: false},
+	{Line: 4, Input: Fine{PercentageOnTotal: 0.0}, Expected: false},
+	{Line: 5, Input: Fine{PercentageOnTotal: 1}, Expected: true},
+	{Line: 6, Input: Fine{PercentageOnTotal: 2.23}, Expected: true},
+}
+
+var hasDaysAfterExpirationDateFineParameters = []testFineParameter{
+	{Line: 1, Input: Fine{DaysAfterExpirationDate: 0, AmountInCents: 0, PercentageOnTotal: 0}, Expected: false},
+	{Line: 2, Input: Fine{DaysAfterExpirationDate: 0, AmountInCents: 1, PercentageOnTotal: 0}, Expected: false},
+	{Line: 3, Input: Fine{DaysAfterExpirationDate: 0, AmountInCents: 0, PercentageOnTotal: 1.2}, Expected: false},
+	{Line: 4, Input: Fine{DaysAfterExpirationDate: 1, AmountInCents: 1, PercentageOnTotal: 0.0}, Expected: true},
+	{Line: 5, Input: Fine{DaysAfterExpirationDate: 1, AmountInCents: 0, PercentageOnTotal: 1.2}, Expected: true},
+	{Line: 6, Input: Fine{DaysAfterExpirationDate: 2, AmountInCents: 0, PercentageOnTotal: 1.2}, Expected: true},
+}
+
+func TestHasFine(t *testing.T) {
+	for _, fact := range hasFineParameters {
 		input := fact.Input.(Fine)
 
-		result := input.IsValid(fact.AmountInCents.(int))
+		result := input.HasFine()
 
-		assert.Equal(t, fact.Expected, result, fmt.Sprintf("Teste %d: Os juros não foram validados corretamente", i))
-		i++
+		assert.Equal(t, fact.Expected, result, fmt.Sprintf("HasFine - Linha %d: Deve verificar corretamente se possui multa", fact.Line.(int)))
+	}
+}
+
+func TestHasAmountInCents(t *testing.T) {
+	for _, fact := range hasAmountInCentsParameters {
+		input := fact.Input.(Fine)
+
+		result := input.HasAmountInCents()
+
+		assert.Equal(t, fact.Expected, result, fmt.Sprintf("HasAmountInCents - Linha %d: Deve verificar corretamente se possui multa por valor", fact.Line.(int)))
+	}
+}
+
+func TestFineValidate(t *testing.T) {
+	for _, fact := range validateFineParameters {
+		input := fact.Input.(Fine)
+
+		result := input.Validate() == nil
+
+		assert.Equal(t, fact.Expected, result, fmt.Sprintf("Validate - Linha %d: Deve validar a struct de multa", fact.Line.(int)))
+	}
+}
+
+func TestFineHasExclusiveRateValues(t *testing.T) {
+	for _, fact := range hasExclusiveRateValuesFineParameters {
+		input := fact.Input.(Fine)
+
+		result := input.HasExclusiveRateValues()
+
+		assert.Equal(t, fact.Expected, result, fmt.Sprintf("HasExclusiveRateValues - Linha %d: Deve validar corretamente as regras de valores", fact.Line.(int)))
+	}
+}
+
+func TestHasPercentageOnTotal(t *testing.T) {
+	for _, fact := range hasPercentageOnTotalParameters {
+		input := fact.Input.(Fine)
+
+		result := input.HasPercentageOnTotal()
+
+		assert.Equal(t, fact.Expected, result, fmt.Sprintf("HasPercentageOnTotal - Linha %d: Deve validar corretamente o campo Percentage", fact.Line.(int)))
+	}
+}
+
+func TestFineHasDaysAfterExpirationDate(t *testing.T) {
+	for _, fact := range hasDaysAfterExpirationDateFineParameters {
+		input := fact.Input.(Fine)
+
+		result := input.HasDaysAfterExpirationDate()
+
+		assert.Equal(t, fact.Expected, result, fmt.Sprintf("HasDaysAfterExpirationDate - Linha %d: Deve validar corretamente o campo Days", fact.Line.(int)))
 	}
 }

--- a/models/interest_test.go
+++ b/models/interest_test.go
@@ -8,38 +8,123 @@ import (
 )
 
 type testInterestParameter struct {
-	Input         interface{}
-	Expected      interface{}
-	AmountInCents interface{}
+	Line     interface{}
+	Input    interface{}
+	Expected interface{}
 }
 
-var interestParameters = []testInterestParameter{
-	{Input: Interest{Type: "Percentual", Days: 0, Rate: 0.020}, AmountInCents: 0, Expected: true},
-	{Input: Interest{Type: "Percentual ", Days: 0, Rate: 0.020}, AmountInCents: 0, Expected: false},
-	{Input: Interest{Type: "PERCENTUAL", Days: 0, Rate: 0.020}, AmountInCents: 0, Expected: true},
-	{Input: Interest{Type: "pErCeNtUaL", Days: 0, Rate: 0.020}, AmountInCents: 0, Expected: true},
-	{Input: Interest{Type: "Porcentagem", Days: 0, Rate: 0.020}, AmountInCents: 0, Expected: false},
-	{Input: Interest{Type: "Percentual", Days: -1, Rate: 0.020}, AmountInCents: 0, Expected: false},
-	{Input: Interest{Type: "Percentual", Days: 0, Rate: 0.021}, AmountInCents: 0, Expected: false},
-	{Input: Interest{Type: "Percentual", Days: 0, Rate: 0.0201}, AmountInCents: 0, Expected: false},
-	{Input: Interest{Type: "Percentual", Days: 0, Rate: 0.02001}, AmountInCents: 0, Expected: false},
-	{Input: Interest{Type: "Percentual", Days: 0, Rate: 0.020001}, AmountInCents: 0, Expected: false},
-	{Input: Interest{Type: "Nominal", Days: 0, Rate: 2.00}, AmountInCents: 100, Expected: true},
-	{Input: Interest{Type: "NOMINAL", Days: 0, Rate: 2.00}, AmountInCents: 100, Expected: true},
-	{Input: Interest{Type: "nOmInAl", Days: 0, Rate: 2.00}, AmountInCents: 100, Expected: true},
-	{Input: Interest{Type: "Absoluto", Days: 0, Rate: 2.00}, AmountInCents: 100, Expected: false},
-	{Input: Interest{Type: "Nominal", Days: 0, Rate: 3.00}, AmountInCents: 100, Expected: false},
-	{Input: Interest{Type: "Nominal", Days: 0, Rate: 3.00}, AmountInCents: 0, Expected: false},
+var hasInterestParameters = []testInterestParameter{
+	{Line: 4, Input: Interest{DaysAfterExpirationDate: 1, AmountPerDayInCents: 1, PercentagePerMonth: 0}, Expected: true},
+	{Line: 5, Input: Interest{DaysAfterExpirationDate: 1, AmountPerDayInCents: 0, PercentagePerMonth: 1.20}, Expected: true},
+	{Line: 6, Input: Interest{DaysAfterExpirationDate: 1, AmountPerDayInCents: 200, PercentagePerMonth: 3}, Expected: true},
 }
 
-func TestInterest_IsValid(t *testing.T) {
-	i := 1
-	for _, fact := range interestParameters {
+var hasAmountPerDayInCentsParameters = []testInterestParameter{
+	{Line: 1, Input: Interest{AmountPerDayInCents: 0}, Expected: false},
+	{Line: 2, Input: Interest{AmountPerDayInCents: 1}, Expected: true},
+	{Line: 3, Input: Interest{AmountPerDayInCents: 20034}, Expected: true},
+}
+
+var validateParameters = []testFineParameter{
+	{Line: 1, Input: Interest{DaysAfterExpirationDate: 1, AmountPerDayInCents: 0, PercentagePerMonth: 0}, Expected: false},
+	{Line: 2, Input: Interest{DaysAfterExpirationDate: 1, AmountPerDayInCents: 1, PercentagePerMonth: 0}, Expected: true},
+	{Line: 3, Input: Interest{DaysAfterExpirationDate: 1, AmountPerDayInCents: 0, PercentagePerMonth: 1}, Expected: true},
+	{Line: 4, Input: Interest{DaysAfterExpirationDate: 1, AmountPerDayInCents: 1, PercentagePerMonth: 1}, Expected: false},
+	{Line: 5, Input: Interest{DaysAfterExpirationDate: 1, PercentagePerMonth: -1}, Expected: false},
+	{Line: 6, Input: Interest{DaysAfterExpirationDate: 1, PercentagePerMonth: -2.34}, Expected: false},
+	{Line: 7, Input: Interest{DaysAfterExpirationDate: 1, PercentagePerMonth: 0}, Expected: false},
+	{Line: 8, Input: Interest{DaysAfterExpirationDate: 1, PercentagePerMonth: 0.0}, Expected: false},
+	{Line: 9, Input: Interest{DaysAfterExpirationDate: 1, PercentagePerMonth: 1}, Expected: true},
+	{Line: 10, Input: Interest{DaysAfterExpirationDate: 1, PercentagePerMonth: 2.23}, Expected: true},
+	{Line: 11, Input: Interest{DaysAfterExpirationDate: 0, AmountPerDayInCents: 0, PercentagePerMonth: 0}, Expected: false},
+	{Line: 12, Input: Interest{DaysAfterExpirationDate: 0, AmountPerDayInCents: 1, PercentagePerMonth: 0}, Expected: false},
+	{Line: 13, Input: Interest{DaysAfterExpirationDate: 0, AmountPerDayInCents: 0, PercentagePerMonth: 1.2}, Expected: false},
+	{Line: 14, Input: Interest{DaysAfterExpirationDate: 1, AmountPerDayInCents: 1, PercentagePerMonth: 0.0}, Expected: true},
+	{Line: 15, Input: Interest{DaysAfterExpirationDate: 1, AmountPerDayInCents: 0, PercentagePerMonth: 1.2}, Expected: true},
+	{Line: 16, Input: Interest{DaysAfterExpirationDate: 2, AmountPerDayInCents: 0, PercentagePerMonth: 1.2}, Expected: true},
+}
+
+var hasExclusiveRateValuesParameters = []testInterestParameter{
+	{Line: 1, Input: Interest{AmountPerDayInCents: 0, PercentagePerMonth: 0}, Expected: false},
+	{Line: 2, Input: Interest{AmountPerDayInCents: 1, PercentagePerMonth: 0}, Expected: true},
+	{Line: 3, Input: Interest{AmountPerDayInCents: 0, PercentagePerMonth: 1}, Expected: true},
+	{Line: 4, Input: Interest{AmountPerDayInCents: 1, PercentagePerMonth: 1}, Expected: false},
+}
+
+var hasPercentagePerMonthParameters = []testInterestParameter{
+	{Line: 1, Input: Interest{PercentagePerMonth: -1}, Expected: false},
+	{Line: 2, Input: Interest{PercentagePerMonth: -2.34}, Expected: false},
+	{Line: 3, Input: Interest{PercentagePerMonth: 0}, Expected: false},
+	{Line: 4, Input: Interest{PercentagePerMonth: 0.0}, Expected: false},
+	{Line: 5, Input: Interest{PercentagePerMonth: 1}, Expected: true},
+	{Line: 6, Input: Interest{PercentagePerMonth: 2.23}, Expected: true},
+}
+
+var hasDaysAfterExpirationDateParameters = []testInterestParameter{
+	{Line: 1, Input: Interest{DaysAfterExpirationDate: 0, AmountPerDayInCents: 0, PercentagePerMonth: 0}, Expected: false},
+	{Line: 2, Input: Interest{DaysAfterExpirationDate: 0, AmountPerDayInCents: 1, PercentagePerMonth: 0}, Expected: false},
+	{Line: 3, Input: Interest{DaysAfterExpirationDate: 0, AmountPerDayInCents: 0, PercentagePerMonth: 1.2}, Expected: false},
+	{Line: 4, Input: Interest{DaysAfterExpirationDate: 1, AmountPerDayInCents: 1, PercentagePerMonth: 0.0}, Expected: true},
+	{Line: 5, Input: Interest{DaysAfterExpirationDate: 1, AmountPerDayInCents: 0, PercentagePerMonth: 1.2}, Expected: true},
+	{Line: 6, Input: Interest{DaysAfterExpirationDate: 2, AmountPerDayInCents: 0, PercentagePerMonth: 1.2}, Expected: true},
+}
+
+func TestHasInterest(t *testing.T) {
+	for _, fact := range hasInterestParameters {
 		input := fact.Input.(Interest)
 
-		result := input.IsValid(fact.AmountInCents.(int))
+		result := input.HasInterest()
 
-		assert.Equal(t, fact.Expected, result, fmt.Sprintf("Teste %d: A multa não foi validada corretamente", i))
-		i++
+		assert.Equal(t, fact.Expected, result, fmt.Sprintf("HasInterest - Linha %d: Os juros não foram validados corretamente", fact.Line.(int)))
+	}
+}
+
+func TestHasAmountPerDayInCents(t *testing.T) {
+	for _, fact := range hasAmountPerDayInCentsParameters {
+		input := fact.Input.(Interest)
+
+		result := input.HasAmountPerDayInCents()
+
+		assert.Equal(t, fact.Expected, result, fmt.Sprintf("HasAmountPerDayInCents - Linha %d: Os juros não foram validados corretamente", fact.Line.(int)))
+	}
+}
+
+func TestValidate(t *testing.T) {
+	for _, fact := range validateParameters {
+		input := fact.Input.(Interest)
+
+		result := input.Validate() == nil
+
+		assert.Equal(t, fact.Expected, result, fmt.Sprintf("Validate - Linha %d: Deve validar a struct de juros", fact.Line.(int)))
+	}
+}
+
+func TestHasExclusiveRateValues(t *testing.T) {
+	for _, fact := range hasExclusiveRateValuesParameters {
+		input := fact.Input.(Interest)
+
+		result := input.HasExclusiveRateValues()
+
+		assert.Equal(t, fact.Expected, result, fmt.Sprintf("HasExclusiveRateValues - Linha %d: Deve validar corretamente as regras de valores", fact.Line.(int)))
+	}
+}
+
+func TestHasPercentagePerMonth(t *testing.T) {
+	for _, fact := range hasPercentagePerMonthParameters {
+		input := fact.Input.(Interest)
+
+		result := input.HasPercentagePerMonth()
+
+		assert.Equal(t, fact.Expected, result, fmt.Sprintf("HasPercentagePerMonth - Linha %d: Deve validar corretamente o campo Percentage", fact.Line.(int)))
+	}
+}
+
+func TestHasDaysAfterExpirationDate(t *testing.T) {
+	for _, fact := range hasDaysAfterExpirationDateParameters {
+		input := fact.Input.(Interest)
+
+		result := input.HasDaysAfterExpirationDate()
+
+		assert.Equal(t, fact.Expected, result, fmt.Sprintf("HasDaysAfterExpirationDate - Linha %d: Deve validar corretamente o campo Days", fact.Line.(int)))
 	}
 }

--- a/models/title.go
+++ b/models/title.go
@@ -20,6 +20,7 @@ type Title struct {
 	NSU            string    `json:"nsu,omitempty"`
 	BoletoType     string    `json:"boletoType,omitempty"`
 	Rules          *Rules    `json:"rules,omitempty"`
+	Fees           *Fees     `json:"fees,omitempty"`
 	BoletoTypeCode string
 }
 
@@ -71,6 +72,11 @@ func (t *Title) IsAmountInCentsValid() error {
 //HasRules Verifica se o nó de rules está preenchido
 func (t *Title) HasRules() bool {
 	return t.Rules != nil
+}
+
+//HasFees Verifica se o nó de fees está preenchido
+func (t *Title) HasFees() bool {
+	return t.Fees != nil
 }
 
 func parseDate(t string) (time.Time, error) {

--- a/test/boleto_pact_provider_test.go
+++ b/test/boleto_pact_provider_test.go
@@ -67,6 +67,18 @@ func TestMessageProvider_Success(t *testing.T) {
 						DocumentNumber: "1234567890",
 						NSU:            "123",
 						BoletoType:     "ND",
+						Fees: &models.Fees{
+							Fine: &models.Fine{
+								DaysAfterExpirationDate: 1,
+								AmountInCents:           200,
+								PercentageOnTotal:       1,
+							},
+							Interest: &models.Interest{
+								DaysAfterExpirationDate: 1,
+								AmountPerDayInCents:     200,
+								PercentagePerMonth:      1,
+							},
+						},
 						BoletoTypeCode: "19",
 					},
 					Recipient: models.Recipient{

--- a/tmpl/funcmaps.go
+++ b/tmpl/funcmaps.go
@@ -72,6 +72,9 @@ var funcMap = template.FuncMap{
 	"truncateOnly":                       truncateOnly,
 	"toUint":                             toUint,
 	"strToFloat":                         strToFloat,
+	"float64ToString":                    float64ToString,
+	"datePlusDays":                       datePlusDays,
+	"datePlusDaysConsideringZeroAsStart": datePlusDaysConsideringZeroAsStart,
 }
 
 func GetFuncMaps() template.FuncMap {
@@ -180,6 +183,10 @@ func strToFloat(n string) float64 {
 	return s
 }
 
+func float64ToString(format string, value float64) string {
+	return fmt.Sprintf(format, value)
+}
+
 func fmtDoc(doc models.Document) string {
 	if e := doc.ValidateCPF(); e == nil {
 		return fmtCPF(doc.Number)
@@ -222,6 +229,16 @@ func brDate(d time.Time) string {
 
 func enDate(d time.Time, del string) string {
 	return d.Format("2006" + del + "01" + del + "02")
+}
+
+func datePlusDays(date time.Time, days uint) time.Time {
+	timeToPlus := time.Hour * 24 * time.Duration(days)
+	return date.UTC().Add(timeToPlus)
+}
+
+func datePlusDaysConsideringZeroAsStart(date time.Time, days uint) time.Time {
+	daysConsideringZeroAsStart := days - 1
+	return datePlusDays(date, daysConsideringZeroAsStart)
 }
 
 func brDateWithoutDelimiter(d time.Time) string {

--- a/tmpl/funcmaps_test.go
+++ b/tmpl/funcmaps_test.go
@@ -3,6 +3,7 @@ package tmpl
 import (
 	"html/template"
 	"testing"
+	"time"
 
 	"github.com/mundipagg/boleto-api/models"
 	"github.com/mundipagg/boleto-api/test"
@@ -100,6 +101,16 @@ var joinStringsParameters = []test.Parameter{
 	{Input: []string{" ", " ", " "}, Expected: "     "},
 	{Input: []string{"", "", "", "", ""}, Expected: "    "},
 	{Input: []string{"ÁÉÍÓÚÀ", "()*&=-+!:?<", "^~|ºª§°¹²³£¢¬\\\"", "@#$%"}, Expected: "ÁÉÍÓÚÀ ()*&=-+!:?< ^~|ºª§°¹²³£¢¬\\\" @#$%"},
+}
+
+var float64ToStringParameters = []test.Parameter{
+	{Input: -2.0, Expected: "-2.00"},
+	{Input: -2.4, Expected: "-2.40"},
+	{Input: 0.0, Expected: "0.00"},
+	{Input: 0.02, Expected: "0.02"},
+	{Input: 1.0, Expected: "1.00"},
+	{Input: 1.23, Expected: "1.23"},
+	{Input: 1.2379, Expected: "1.24"},
 }
 
 func TestShouldPadLeft(t *testing.T) {
@@ -286,5 +297,34 @@ func TestTruncateOnly(t *testing.T) {
 	for _, fact := range truncateOnlyParameters {
 		result := truncateOnly(fact.Input.(string), fact.Length)
 		assert.Equal(t, fact.Expected, result, "Deve-se truncar uma string corretamente")
+	}
+}
+
+func TestDatePlusDays(t *testing.T) {
+	var daysToAdd uint = 2
+	dateNow := time.Now()
+	dateExpected := dateNow.UTC().Add(time.Hour * 24 * time.Duration(daysToAdd))
+
+	result := datePlusDays(dateNow, daysToAdd)
+
+	assert.Equal(t, dateExpected, result, "Deve incrementar na data, os dias passados no método")
+}
+
+func TestDatePlusDaysConsideringZeroAsStart(t *testing.T) {
+	var daysPassedForTheMethod uint = 3
+	var daysCountingFromZero uint = 2
+	dateNow := time.Now()
+	dateExpected := dateNow.UTC().Add(time.Hour * 24 * time.Duration(daysCountingFromZero))
+
+	result := datePlusDaysConsideringZeroAsStart(dateNow, daysPassedForTheMethod)
+
+	assert.Equal(t, dateExpected, result, "Deve incrementar na data, os dias passados no método, considerando o zero como start")
+}
+
+func TestFloat64ToStringWith2f(t *testing.T) {
+	format := "%.2f"
+	for _, fact := range float64ToStringParameters {
+		result := float64ToString(format, fact.Input.(float64))
+		assert.Equal(t, fact.Expected, result, "Deve formatar o float com duas casas decimais e retornar como string")
 	}
 }


### PR DESCRIPTION
# Descrição

### Tarefa [BPROC-368](https://mundipagg.atlassian.net/browse/BPROC-368) 

A partir desse PR, temos a implementação de registro de boletos com juros e multa no projeto boleto-api, para o provedor Caixa. 

### Tipos de alterações

- [ ] Correção de bug 
- [x] Nova feature 
- [ ] Alteração ou remoção de funcionalidade existente
- [ ] Atualização de documentação

## Testes Locais

### Testes unitários / Integração caixa branca

![image](https://user-images.githubusercontent.com/36340027/155135032-0bf1139e-6bfb-40d4-9d5a-54af246d1b43.png)

## Testes Staging
As descrições dos cenários de teste estão no [CARD](https://mundipagg.atlassian.net/browse/BPROC-368)

### CENÁRIO 1 - Requisição com dados de juros corretos, provedor caixa
Evidências: 

![image](https://user-images.githubusercontent.com/36340027/155147984-45f9e284-d73a-45d9-81a7-292353bd3f63.png)

![image](https://user-images.githubusercontent.com/36340027/155148061-557f76b0-f28f-4d2d-9389-6ccf21a799ce.png)

![image](https://user-images.githubusercontent.com/36340027/155148250-1b81fa5d-e268-46e4-ac68-35083b46a1b8.png)

![image](https://user-images.githubusercontent.com/36340027/155148332-d703cdf6-dd69-4946-a036-f4a0a684d68f.png)

### CENÁRIO 2 - Requisição com dados de multa corretos, provedor caixa
Evidências: 

![image](https://user-images.githubusercontent.com/36340027/155148899-3903c1f4-45ca-4ac9-9326-adda43ae5e2f.png)

![image](https://user-images.githubusercontent.com/36340027/155149009-b35fed82-5f24-4b10-b6f9-ad2eca5bab5b.png)

![image](https://user-images.githubusercontent.com/36340027/155149134-536e767e-80fe-484a-ab86-f8f4f408a7b8.png)

![image](https://user-images.githubusercontent.com/36340027/155149410-15118228-b93a-477b-b96b-b5f2533e6500.png)

### CENÁRIO 3 - Requisição com dados de juros e multa corretos, provedor caixa
Evidências: 

![image](https://user-images.githubusercontent.com/36340027/155149607-c6b969fd-566f-4522-ab05-ca40915c838e.png)

![image](https://user-images.githubusercontent.com/36340027/155149739-7be9b9bf-c3d8-4e31-b8d4-5a9a526244a4.png)

### CENÁRIO 4 - Requisição sem dados de juros e multa, provedor caixa
Evidências: 

![image](https://user-images.githubusercontent.com/36340027/155149854-81ee94ec-b049-4f0d-a9da-6da6d0f99f29.png)

![image](https://user-images.githubusercontent.com/36340027/155149935-f89eb46b-bea3-4126-89ad-a0f237fcbe4e.png)

![image](https://user-images.githubusercontent.com/36340027/155150026-539de2be-420a-4524-ba94-588c77cae428.png)

![image](https://user-images.githubusercontent.com/36340027/155150088-f8a9e26e-cc53-46d7-b8a6-1b476c3ede84.png)

![image](https://user-images.githubusercontent.com/36340027/155150159-5e48d06d-f9d8-4253-9409-9f8cdb8b43e1.png)

![image](https://user-images.githubusercontent.com/36340027/155150231-d03ab232-d9ca-43d7-9170-8ada01fcd662.png)

### CENÁRIO 5 - Requisição com o valor e porcentagem de juros preenchidos, provedor caixa
Evidências: 

![image](https://user-images.githubusercontent.com/36340027/155150445-8f416029-b968-4483-8c15-58b0348ea463.png)

### CENÁRIO 6 - Requisição com o valor e porcentagem de multa preenchidos, provedor caixa
Evidências: 

![image](https://user-images.githubusercontent.com/36340027/155150587-98d8d56a-7aa6-470d-b1ff-c7d32139b72f.png)

### CENÁRIO 7 - Requisição com o valor de juros negativo, provedor caixa
Evidências: 

![image](https://user-images.githubusercontent.com/36340027/155151117-bfb2bc32-48d0-40f4-a39b-fed7e68ed429.png)

![image](https://user-images.githubusercontent.com/36340027/155151204-87088c7c-40e8-491f-8e07-1088b9b6074a.png)

### CENÁRIO 8 - Requisição com o valor de multa negativo, provedor caixa
Evidências: 

![image](https://user-images.githubusercontent.com/36340027/155151289-2e02ee65-119d-42e0-b855-3d3547b737e3.png)

![image](https://user-images.githubusercontent.com/36340027/155151368-cbe4eb6f-8ae9-48a5-a442-e0e022983f7c.png)

### CENÁRIO 9 - Requisição com quantidade de dias de multa negativo, provedor caixa
Evidências: 

![image](https://user-images.githubusercontent.com/36340027/155151568-f3a4c503-2776-4e2c-b5c6-a1a8488578dd.png)

### CENÁRIO 10 - Requisição com quantidade de dias de multa 0, provedor caixa
Evidências: 

![image](https://user-images.githubusercontent.com/36340027/155151651-8b574135-1654-41a0-8c00-4cb0bb114e77.png)

![image](https://user-images.githubusercontent.com/36340027/155151714-9d6d4c9f-2af0-4271-9318-255d1f6a0d66.png)

### CENÁRIO 11 - Requisição com quantidade de dias de juros negativo, provedor caixa
Evidências: 

![image](https://user-images.githubusercontent.com/36340027/155152258-989a9a34-0a4f-46a8-9698-3bf3bda264c0.png)

### CENÁRIO 12 - Requisição com quantidade de dias de juros 0, provedor caixa
Evidências: 

![image](https://user-images.githubusercontent.com/36340027/155152332-97e2dcd9-b707-4598-9dc3-999df7c1c7b8.png)

![image](https://user-images.githubusercontent.com/36340027/155152408-cbf0cf78-94a1-4f02-893a-2615f1687cad.png)

### CENÁRIO 13 - Requisição com dados de juros e multa incorretos, provedor caixa
Evidências: 

![image](https://user-images.githubusercontent.com/36340027/155153129-c086408f-6adc-446d-abb4-2905939aeeb3.png)

![image](https://user-images.githubusercontent.com/36340027/155153240-afb0c155-6e4d-4ca5-883d-50b0f29bbaf3.png)

### CENÁRIO 14 - Requisição sem dados de juros e multa, para outros provedores
Evidências: 

Banco do Brasil 
![image](https://user-images.githubusercontent.com/36340027/155153372-1e2475fa-540b-406d-bc01-dc99eb0c118d.png)

BradescoNetEmpresa
![image](https://user-images.githubusercontent.com/36340027/155153450-d7e48e6f-80cd-4c96-8efe-82730772d337.png)

BradescoShopFacil
![image](https://user-images.githubusercontent.com/36340027/155153703-1bede098-9ee3-4273-a135-e6800171cd0c.png)

Itau
![image](https://user-images.githubusercontent.com/36340027/155153812-b1d8d5b3-8859-4e74-bca5-cd0cb514e65b.png)

JPMorgan
![image](https://user-images.githubusercontent.com/36340027/155153855-78ef49bf-44e2-42b2-a70d-f9f12149ff0d.png)

Pefisa
![image](https://user-images.githubusercontent.com/36340027/155153916-1d064698-ac82-4e39-94b0-1f471108c366.png)

Santander
![image](https://user-images.githubusercontent.com/36340027/155153967-48dd0abd-565a-4170-9625-17617a1c75e3.png)

Stone
![image](https://user-images.githubusercontent.com/36340027/155154031-7339f17d-3822-4a60-b58d-646fc753c4c0.png)

### CENÁRIO 15 - Requisição com dados de juros e multa, para outros provedores 
Evidências: 

Banco do Brasil 
![image](https://user-images.githubusercontent.com/36340027/155155582-8bdeebea-1b75-4b70-8b5d-c884871e751b.png)

BradescoNetEmpresa
![image](https://user-images.githubusercontent.com/36340027/155155686-09a6b785-42f3-430b-b9d9-8b8bc6225ee6.png)

BradescoShopFacil
![image](https://user-images.githubusercontent.com/36340027/155155806-221e7841-1465-4637-99b4-19b76a25a3d8.png)

Itau
![image](https://user-images.githubusercontent.com/36340027/155155962-3308c942-f66e-4493-aca6-4599a7e7626c.png)

JPMorgan
![image](https://user-images.githubusercontent.com/36340027/155156223-3dfe2d46-9b8a-47e1-8f08-e4efd9170ba6.png)

Pefisa
![image](https://user-images.githubusercontent.com/36340027/155156501-32c6b113-b021-4421-8cce-c7a64370ab8f.png)

Santander
![image](https://user-images.githubusercontent.com/36340027/155156698-00d3abfb-c14f-4c71-a6f6-89efd3c7c64e.png)

Stone
![image](https://user-images.githubusercontent.com/36340027/155157019-3d01d8c2-6a8f-4834-967e-fa1579827f0a.png)

### CENÁRIO 16 - Requisição com dados de juros e multa e com boleto_rules com no_strict, provedor caixa 
Evidências: 

![image](https://user-images.githubusercontent.com/36340027/155210647-a975dd60-a17c-4cd1-9461-895def689302.png)

![image](https://user-images.githubusercontent.com/36340027/155210706-bbfaf816-d1da-4573-9e38-b61eef38bb3a.png)

![image](https://user-images.githubusercontent.com/36340027/155210793-8a4f1d9e-c0b7-4618-8754-400fbc1f5ee2.png)

![image](https://user-images.githubusercontent.com/36340027/155210824-44c10d27-4505-44ee-ad98-88cf5a7a4f66.png)

![image](https://user-images.githubusercontent.com/36340027/155211032-17e014ea-02c4-4ce1-b0f7-8acb4e6e779d.png)

![image](https://user-images.githubusercontent.com/36340027/155211082-a4333921-1f1a-4451-9a33-eefc18eca7d3.png)

![image](https://user-images.githubusercontent.com/36340027/155211123-69da8f85-f614-4067-b188-37429d1c608a.png)

![image](https://user-images.githubusercontent.com/36340027/155211183-88c09c8c-9320-44ec-9f15-cc2f843e1289.png)

## Checklist

- [x] Associei corretamente a Tarefa do Board ao Pull Request.
- [x] Meu código segue as diretrizes desse projeto.
- [x] Eu revisei meu próprio código.
- [x] Eu comentei meu código em áreas particulares de difícil compreensão.
- [x] Eu atualizei a documentação de acordo com as mudanças realizadas.
- [x] Meu código não gerou novos warnings.
- [x] Eu adicionei testes que provam que minha correção é efetiva ou que a nova feature funciona.
- [x] Testes novos e existentes passam localmente com minhas alterações. 
- [x] Testes novos e existentes passam em staging com minhas alterações. 
- [x] Qualquer dependência dessa alteração já foi realizada (deploy, configuração em todos os ambientes, etc).
