### PR TITLE
[BPROC-389] Adição de campo Sacador Avalista na CEF no request e no layout do boleto

### DIFF
--- a/boleto/templateCaixa.go
+++ b/boleto/templateCaixa.go
@@ -416,8 +416,13 @@ const boletoFormCaixa = `
                             <td>&nbsp;</td>
                         </tr>
                         <tr>
+                        {{if .View.Boleto.HasPayeeGuarantor}}
+                            <td><span class="text"><b>Sacador/Avalista: </b> &nbsp;{{.View.Boleto.PayeeGuarantor.Name}}</span></td>
+                            <td><span class="text"><b>CNPJ/CPF: </b> &nbsp;{{fmtDoc .View.Boleto.PayeeGuarantor.Document}}</span></td>
+                        {{else}}
                             <td><span class="text"><b>Sacador/Avalista: </b> &nbsp;</span></td>
                             <td><span class="text"><b>CNPJ/CPF: </b> &nbsp;</span></td>
+                        {{end}}     
                         </tr>
                     </table>
                 </td>

--- a/caixa/caixa.go
+++ b/caixa/caixa.go
@@ -34,6 +34,8 @@ func New() bankCaixa {
 	b.validate.Push(validations.ValidateExpireDate)
 	b.validate.Push(validations.ValidateBuyerDocumentNumber)
 	b.validate.Push(validations.ValidateRecipientDocumentNumber)
+	b.validate.Push(validations.ValidatePayeeGuarantorDocumentNumber)
+	b.validate.Push(validations.ValidatePayeeGuarantorName)
 	b.validate.Push(caixaValidateAgency)
 	b.validate.Push(validadeOurNumber)
 	b.validate.Push(caixaValidateBoletoType)

--- a/caixa/request.go
+++ b/caixa/request.go
@@ -100,16 +100,27 @@ const requestToCaixa = `
                         <CEP>{{truncateOnly (replace (clearStringCaixa .Buyer.Address.ZipCode) "-" "") 8}}</CEP>
                      </ENDERECO>
                   </PAGADOR>
-               {{if .Title.Fees.HasFine}}                 
-                  <MULTA>
-                     <DATA>{{enDate (datePlusDaysConsideringZeroAsStart .Title.ExpireDateTime .Title.Fees.Fine.DaysAfterExpirationDate) "-"}}</DATA> 
-                  {{if .Title.Fees.Fine.HasAmountInCents}}
-                     <VALOR>{{toFloatStr .Title.Fees.Fine.AmountInCents}}</VALOR>
-                  {{else}}
-                     <PERCENTUAL>{{float64ToString "%.2f" .Title.Fees.Fine.PercentageOnTotal}}</PERCENTUAL>
+                  {{if .HasPayeeGuarantor}}
+                     <SACADOR_AVALISTA>
+                        {{if eq .PayeeGuarantor.Document.Type "CPF"}}
+                              <CPF>{{.PayeeGuarantor.Document.Number}}</CPF> 
+                              <NOME>{{truncateOnly (clearStringCaixa (.PayeeGuarantor.Name)) 40}}</NOME> 
+                        {{else}}
+                              <CNPJ>{{.PayeeGuarantor.Document.Number}}</CNPJ>
+                              <RAZAO_SOCIAL>{{truncateOnly (clearStringCaixa (.PayeeGuarantor.Name)) 40}}</RAZAO_SOCIAL>
+                        {{end}}
+                     </SACADOR_AVALISTA>
                   {{end}}
-                  </MULTA>
-               {{end}}
+                  {{if .Title.Fees.HasFine}}                 
+                     <MULTA>
+                        <DATA>{{enDate (datePlusDaysConsideringZeroAsStart .Title.ExpireDateTime .Title.Fees.Fine.DaysAfterExpirationDate) "-"}}</DATA> 
+                     {{if .Title.Fees.Fine.HasAmountInCents}}
+                        <VALOR>{{toFloatStr .Title.Fees.Fine.AmountInCents}}</VALOR>
+                     {{else}}
+                        <PERCENTUAL>{{float64ToString "%.2f" .Title.Fees.Fine.PercentageOnTotal}}</PERCENTUAL>
+                     {{end}}
+                     </MULTA>
+                  {{end}}
                   <FICHA_COMPENSACAO>
                      <MENSAGENS>
                         <MENSAGEM>{{truncateOnly (clearStringCaixa .Title.Instructions) 40}}</MENSAGEM>

--- a/caixa/validations.go
+++ b/caixa/validations.go
@@ -95,7 +95,6 @@ func caixaValidateInterest(b interface{}) error {
 				return err
 			}
 		}
-
 		return nil
 	default:
 		return validations.InvalidType(t)
@@ -110,7 +109,6 @@ func caixaValidateFine(b interface{}) error {
 				return err
 			}
 		}
-
 		return nil
 	default:
 		return validations.InvalidType(t)

--- a/models/boleto.go
+++ b/models/boleto.go
@@ -19,13 +19,14 @@ import (
 
 // BoletoRequest entidade de entrada para o boleto
 type BoletoRequest struct {
-	Authentication Authentication `json:"authentication"`
-	Agreement      Agreement      `json:"agreement"`
-	Title          Title          `json:"title"`
-	Recipient      Recipient      `json:"recipient"`
-	Buyer          Buyer          `json:"buyer"`
-	BankNumber     BankNumber     `json:"bankNumber"`
-	RequestKey     string         `json:"requestKey,omitempty"`
+	Authentication Authentication  `json:"authentication"`
+	Agreement      Agreement       `json:"agreement"`
+	Title          Title           `json:"title"`
+	Recipient      Recipient       `json:"recipient"`
+	PayeeGuarantor *PayeeGuarantor `json:"payeeGuarantor,omitempty"`
+	Buyer          Buyer           `json:"buyer"`
+	BankNumber     BankNumber      `json:"bankNumber"`
+	RequestKey     string          `json:"requestKey,omitempty"`
 }
 
 // BoletoResponse entidade de saída para o boleto
@@ -221,6 +222,11 @@ func BoletoErrorConector(e *flow.ExchangeMessage, u flow.URI, params ...interfac
 //HasErrors verify if Response has any error
 func (b *BoletoResponse) HasErrors() bool {
 	return b.Errors != nil && len(b.Errors) > 0
+}
+
+//HasPayeeGuarantor verify if PayeeGuarantor is not nil
+func (b BoletoRequest) HasPayeeGuarantor() bool {
+	return b.PayeeGuarantor != nil
 }
 
 //GetBoletoResponseError Retorna um BoletoResponse com um erro específico

--- a/models/model_test.go
+++ b/models/model_test.go
@@ -88,6 +88,10 @@ var agreementAccountParameters = []ModelTestParameter{
 	{Input: Agreement{Account: "654654654654654654654654654564"}, Length: 8, Expected: false},
 }
 
+var payeeGuarantorParameters = []ModelTestParameter{
+	{Input: PayeeGuarantor{Name: ""}, Expected: false},
+}
+
 func TestIsCpf(t *testing.T) {
 	for _, fact := range isCPFParameters {
 		input := fact.Input.(Document)
@@ -240,5 +244,13 @@ func TestAgreementIsAccountValid(t *testing.T) {
 		input := fact.Input.(Agreement)
 		result := input.IsAccountValid(fact.Length.(int)) == nil
 		assert.Equal(t, fact.Expected, result, "Verifica se a conta é valida")
+	}
+}
+
+func TestPayeeGuarantorNameIsValid(t *testing.T) {
+	for _, fact := range payeeGuarantorParameters {
+		input := fact.Input.(PayeeGuarantor)
+		result := input.HasName()
+		assert.Equal(t, fact.Expected, result, "Verifica se o nome do PayeeGuarantor está preenchido")
 	}
 }

--- a/models/payeeGuarantor.go
+++ b/models/payeeGuarantor.go
@@ -1,0 +1,12 @@
+package models
+
+// PayeeGuarantor informações de entrada do lojista(sacador avalista)
+type PayeeGuarantor struct {
+	Name     string   `json:"name,omitempty"`
+	Document Document `json:"document,omitempty"`
+}
+
+// HasName diz se o Name está preenchido com algum valor
+func (p PayeeGuarantor) HasName() bool {
+	return p.Name != ""
+}

--- a/test/boleto_pact_provider_test.go
+++ b/test/boleto_pact_provider_test.go
@@ -97,6 +97,13 @@ func TestMessageProvider_Success(t *testing.T) {
 							StateCode:  "RJ",
 						},
 					},
+					PayeeGuarantor: &models.PayeeGuarantor{
+						Name: "Nome do PayeeGuarantor (Loja)",
+						Document: models.Document{
+							Type:   "CPF",
+							Number: "11282705792",
+						},
+					},
 					Buyer: models.Buyer{
 						Name:  "Nome do Comprador (Cliente)",
 						Email: "teste@pagar.me",

--- a/test/builder.go
+++ b/test/builder.go
@@ -10,6 +10,7 @@ type BuilderBoletoRequest struct {
 	agreement      models.Agreement
 	title          models.Title
 	recipient      models.Recipient
+	PayeeGuarantor *models.PayeeGuarantor
 	buyer          models.Buyer
 	bank           models.BankNumber
 }
@@ -38,6 +39,10 @@ func (b *BuilderBoletoRequest) SetRecipient(recipient models.Recipient) {
 	b.recipient = recipient
 }
 
+func (b *BuilderBoletoRequest) SetPayeeGuarantor(PayeeGuarantor *models.PayeeGuarantor) {
+	b.PayeeGuarantor = PayeeGuarantor
+}
+
 func (b *BuilderBoletoRequest) SetBuyer(buyer models.Buyer) {
 	b.buyer = buyer
 }
@@ -50,6 +55,7 @@ func (b *BuilderBoletoRequest) BoletoRequest() *models.BoletoRequest {
 		Agreement:      b.agreement,
 		Title:          b.title,
 		Recipient:      b.recipient,
+		PayeeGuarantor: b.PayeeGuarantor,
 		Buyer:          b.buyer,
 		RequestKey:     guid.String(),
 	}

--- a/test/stub.go
+++ b/test/stub.go
@@ -13,6 +13,7 @@ type StubBoletoRequest struct {
 	Agreement      models.Agreement
 	Title          models.Title
 	Recipient      models.Recipient
+	PayeeGuarantor *models.PayeeGuarantor
 	Buyer          models.Buyer
 	bank           models.BankNumber
 }
@@ -98,11 +99,50 @@ func (s *StubBoletoRequest) WithBuyerZipCode(zipcode string) *StubBoletoRequest 
 	return s
 }
 
+func (s *StubBoletoRequest) WithRecipientDocumentType(documentType string) *StubBoletoRequest {
+	s.Recipient.Document.Type = documentType
+	return s
+}
+
+func (s *StubBoletoRequest) WithRecipientName(recipientName string) *StubBoletoRequest {
+	s.Recipient.Name = recipientName
+	return s
+}
+
+func (s *StubBoletoRequest) WithPayeeGuarantorName(PayeeGuarantorName string) *StubBoletoRequest {
+	s.createStubPayeeGuarantor()
+	s.PayeeGuarantor.Name = PayeeGuarantorName
+	return s
+}
+
+func (s *StubBoletoRequest) WithPayeeGuarantorDocumentNumber(docNumber string) *StubBoletoRequest {
+	s.createStubPayeeGuarantor()
+	s.PayeeGuarantor.Document.Number = docNumber
+	return s
+}
+
+func (s *StubBoletoRequest) WithPayeeGuarantorDocumentType(documentType string) *StubBoletoRequest {
+	s.createStubPayeeGuarantor()
+	s.PayeeGuarantor.Document.Type = documentType
+	return s
+}
+
+func (s *StubBoletoRequest) createStubPayeeGuarantor() {
+	if !s.hasStubPayeeGuarantor() {
+		s.PayeeGuarantor = &models.PayeeGuarantor{}
+	}
+}
+
+func (s *StubBoletoRequest) hasStubPayeeGuarantor() bool {
+	return s.PayeeGuarantor != nil
+}
+
 func (s *StubBoletoRequest) Build() *models.BoletoRequest {
 	s.SetAuthentication(s.Authentication)
 	s.SetAgreement(s.Agreement)
 	s.SetTitle(s.Title)
 	s.SetRecipient(s.Recipient)
+	s.SetPayeeGuarantor(s.PayeeGuarantor)
 	s.SetBuyer(s.Buyer)
 	s.SetBank(s.bank)
 	return s.BoletoRequest()

--- a/validations/recipient_document_number.go
+++ b/validations/recipient_document_number.go
@@ -17,3 +17,22 @@ func ValidateRecipientDocumentNumber(b interface{}) error {
 		return InvalidType(t)
 	}
 }
+
+//ValidatePayeeGuarantorDocumentNumber Verifica se o número do documento do lojista é válido
+func ValidatePayeeGuarantorDocumentNumber(b interface{}) error {
+	switch t := b.(type) {
+	case *models.BoletoRequest:
+		if t.HasPayeeGuarantor() {
+			if t.PayeeGuarantor.Document.IsCPF() {
+				return t.PayeeGuarantor.Document.ValidateCPF()
+			}
+			if t.PayeeGuarantor.Document.IsCNPJ() {
+				return t.PayeeGuarantor.Document.ValidateCNPJ()
+			}
+			return models.NewErrorResponse("MPPayeeGuarantorDocumentType", "Tipo de Documento inválido")
+		}
+		return nil
+	default:
+		return InvalidType(t)
+	}
+}

--- a/validations/util.go
+++ b/validations/util.go
@@ -33,3 +33,18 @@ func ModElevenCalculator(a string, m []int) string {
 	}
 	return strconv.Itoa(digit)
 }
+
+//ValidatePayeeGuarantorName Verifica se o nome do lojista é existe
+func ValidatePayeeGuarantorName(b interface{}) error {
+	switch t := b.(type) {
+	case *models.BoletoRequest:
+		if t.HasPayeeGuarantor() {
+			if !t.PayeeGuarantor.HasName() {
+				return models.NewErrorResponse("MPPayeeGuarantorNameType", "Nome do sacador avalista está vazio")
+			}
+		}
+		return nil
+	default:
+		return InvalidType(t)
+	}
+}


### PR DESCRIPTION
# Descrição

### Tarefa [BPROC-389](https://mundipagg.atlassian.net/browse/BPROC-389) 

Este PR adiciona o campo SACADOR_AVALISTA no request para a Caixa. Além disso, Adiciona essas informações no layout do boleto gerado.

### Tipos de alterações

- [ ] Correção de bug 
- [x] Nova feature 
- [ ] Alteração ou remoção de funcionalidade existente
- [ ] Atualização de documentação

## Testes

Foram criados testes unitários e execução da coleção de testes do postman local.

![image](https://user-images.githubusercontent.com/88195864/152857403-36500f8c-a0ef-420c-bbfc-1528aed7f73b.png)

Cenário 1 - Quando envia o campo sacador avalista no request com CNPJ

![image](https://user-images.githubusercontent.com/88195864/157661743-75ffda50-8776-4ba3-b32d-dd1c27392d69.png)

Evidência de response em staging 

![image](https://user-images.githubusercontent.com/88195864/157886681-cff32bf7-93d3-4532-b371-d6f638598611.png)

Cenário 2 - Quando envia o campo sacador avalista no request com CPF

![image](https://user-images.githubusercontent.com/88195864/157661951-520b32fd-eba7-4b20-acb1-bc8bdb7b1c5d.png)

Evidência response em staging 

![image](https://user-images.githubusercontent.com/88195864/157886166-29084cee-88ff-4804-9036-ffa3047e7642.png)

Cenário 3 - Quando não é enviado o campo de sacador avalista

Evidência do request sem o campo sacador avalista
![image](https://user-images.githubusercontent.com/88195864/157886875-9c6c1b12-5a94-4157-bf50-899dd7409026.png)

Evidência response em staging
![image](https://user-images.githubusercontent.com/88195864/157886968-8d2765f0-d898-4fd1-a8cf-2e2aa29a12a3.png)

Cenário 4 - Quando envia o sacador avalista no request com CNPJ deve haver adição dos campos no layout do boleto de CNPJ no html

![image](https://user-images.githubusercontent.com/88195864/157887370-cd10677b-3c1d-4199-bf1a-4a9ebcb988cf.png)

Cenário 5 - Quando envia o sacador avalista no request com CNPJ deve haver adição dos campos no layout do boleto de CNPJ no pdf

![image](https://user-images.githubusercontent.com/88195864/157887573-caead4e3-6c27-4233-b0be-47e128b249e3.png)

Cenário 6 - Quando envia o sacador avalista no request com CPF deve haver adição dos campos no layout do boleto de CPF no html

![image](https://user-images.githubusercontent.com/88195864/157887854-aa0a125a-56a6-49dd-96a0-86e393bc64fc.png)

Cenário 6 - Quando envia o sacador avalista no request com CPF deve haver adição dos campos no layout do boleto de CPF no pdf

![image](https://user-images.githubusercontent.com/88195864/157887957-1aea4d6d-1385-4bf0-bd89-72dee8e95d52.png)

Cenário 7 - Quando não é enviado o sacador avalista no request não deve haver adição dos campos no layout para o html

![image](https://user-images.githubusercontent.com/88195864/157888204-5b55c451-663b-46e9-9ac1-d8ddcc2d17fa.png)

Cenário 7 - Quando não é enviado o sacador avalista no request não deve haver adição dos campos no layout para o pdf

![image](https://user-images.githubusercontent.com/88195864/157888308-adac5b1f-155a-4578-81ce-5358246ee5df.png)

## Checklist

- [ ] Associei corretamente a Tarefa do Board ao Pull Request.
- [x] Meu código segue as diretrizes desse projeto.
- [x] Eu revisei meu próprio código.
- [ ] Eu comentei meu código em áreas particulares de difícil compreensão.
- [ ] Eu atualizei a documentação de acordo com as mudanças realizadas.
- [ ] Meu código não gerou novos warnings.
- [x] Eu adicionei testes que provam que minha correção é efetiva ou que a nova feature funciona.
- [x] Testes novos e existentes passam localmente com minhas alterações. 
- [ ] Testes novos e existentes passam em staging com minhas alterações. 
- [ ] Qualquer dependência dessa alteração já foi realizada (deploy, configuração em todos os ambientes, etc).
