### PR TITLE
[BPROC-366] Adiciona data máxima de vencimento BradescoShopFacil e BradescoNetEmpresa

### DIFF
--- a/api/logger.go
+++ b/api/logger.go
@@ -65,6 +65,9 @@ func loadBankLog(c *gin.Context) *log.Log {
 	l.Operation = "RegisterBoleto"
 	l.NossoNumero = getNossoNumeroFromContext(c)
 	l.Recipient = boleto.Recipient.Name
+	if boleto.HasPayeeGuarantor() {
+		l.PayeeGuarantor = boleto.PayeeGuarantor.Name
+	}
 	l.RequestKey = boleto.RequestKey
 	l.BankName = bank.GetBankNameIntegration()
 	l.IPAddress = c.ClientIP()

--- a/bradescoNetEmpresa/bradescoNetEmpresa.go
+++ b/bradescoNetEmpresa/bradescoNetEmpresa.go
@@ -47,6 +47,7 @@ func New() bankBradescoNetEmpresa {
 	}
 	b.validate.Push(validations.ValidateAmount)
 	b.validate.Push(validations.ValidateExpireDate)
+	b.validate.Push(validations.ValidateMaxExpirationDate)
 	b.validate.Push(validations.ValidateBuyerDocumentNumber)
 	b.validate.Push(validations.ValidateRecipientDocumentNumber)
 	b.validate.Push(validations.ValidateBuyerDocumentNumber)
@@ -56,7 +57,7 @@ func New() bankBradescoNetEmpresa {
 	b.validate.Push(bradescoNetEmpresaValidateAccount)
 	b.validate.Push(bradescoNetEmpresaValidateWallet)
 	b.validate.Push(bradescoNetEmpresaBoletoTypeValidate)
-	b.validate.Push(ValidateMaxExpirationDate)
+
 	return b
 }
 

--- a/bradescoNetEmpresa/bradescoNetEmpresa.go
+++ b/bradescoNetEmpresa/bradescoNetEmpresa.go
@@ -56,6 +56,7 @@ func New() bankBradescoNetEmpresa {
 	b.validate.Push(bradescoNetEmpresaValidateAccount)
 	b.validate.Push(bradescoNetEmpresaValidateWallet)
 	b.validate.Push(bradescoNetEmpresaBoletoTypeValidate)
+	b.validate.Push(ValidateMaxExpirationDate)
 	return b
 }
 

--- a/bradescoNetEmpresa/validations.go
+++ b/bradescoNetEmpresa/validations.go
@@ -3,7 +3,6 @@ package bradescoNetEmpresa
 import (
 	"github.com/mundipagg/boleto-api/models"
 	"github.com/mundipagg/boleto-api/validations"
-	"time"
 )
 
 func bradescoNetEmpresaValidateAgency(b interface{}) error {
@@ -52,23 +51,6 @@ func bradescoNetEmpresaBoletoTypeValidate(b interface{}) error {
 	case *models.BoletoRequest:
 		if len(t.Title.BoletoType) > 0 && bt[t.Title.BoletoType] == "" {
 			return models.NewErrorResponse("MP400", "espécie de boleto informada não existente")
-		}
-		return nil
-	default:
-		return validations.InvalidType(t)
-	}
-}
-
-// bradescoNetEmpresaMaxExpirationDateValidate O emissor Bradesco contém um bug na geração da linha digitável onde,
-// quando a data de vencimento é maior do que 21-02-2025 a linha digitável se torna inválida(O própio Bradesco não consegue ler a linha gerada) e não conseguimos gerar a visualização do boleto
-// Para evitarmos esse problema, adicionamos temporariamente essa trava que bloqueia a geração de boletos com data de vencimento após a data em questão.
-func ValidateMaxExpirationDate(b interface{}) error {
-	maxExpDate, _ := time.Parse("2006-01-02", "2025-02-21")
-
-	switch t := b.(type) {
-	case *models.BoletoRequest:
-		if t.Title.ExpireDateTime.After(maxExpDate) {
-			return models.NewErrorResponse("MPExpireDate", "Data de vencimento não pode ser maior que 21-02-2025")
 		}
 		return nil
 	default:

--- a/bradescoNetEmpresa/validations.go
+++ b/bradescoNetEmpresa/validations.go
@@ -3,6 +3,7 @@ package bradescoNetEmpresa
 import (
 	"github.com/mundipagg/boleto-api/models"
 	"github.com/mundipagg/boleto-api/validations"
+	"time"
 )
 
 func bradescoNetEmpresaValidateAgency(b interface{}) error {
@@ -43,18 +44,6 @@ func bradescoNetEmpresaValidateWallet(b interface{}) error {
 	}
 }
 
-func bradescoNetEmpresaValidateAgreement(b interface{}) error {
-	switch t := b.(type) {
-	case *models.BoletoRequest:
-		if t.Agreement.AgreementNumber == 0 {
-			return models.NewErrorResponse("MP400", "o código do contrato deve ser preenchido")
-		}
-		return nil
-	default:
-		return validations.InvalidType(t)
-	}
-}
-
 func bradescoNetEmpresaBoletoTypeValidate(b interface{}) error {
 	bt := bradescoNetEmpresaBoletoTypes()
 
@@ -63,6 +52,23 @@ func bradescoNetEmpresaBoletoTypeValidate(b interface{}) error {
 	case *models.BoletoRequest:
 		if len(t.Title.BoletoType) > 0 && bt[t.Title.BoletoType] == "" {
 			return models.NewErrorResponse("MP400", "espécie de boleto informada não existente")
+		}
+		return nil
+	default:
+		return validations.InvalidType(t)
+	}
+}
+
+// bradescoNetEmpresaMaxExpirationDateValidate O emissor Bradesco contém um bug na geração da linha digitável onde,
+// quando a data de vencimento é maior do que 21-02-2025 a linha digitável se torna inválida(O própio Bradesco não consegue ler a linha gerada) e não conseguimos gerar a visualização do boleto
+// Para evitarmos esse problema, adicionamos temporariamente essa trava que bloqueia a geração de boletos com data de vencimento após a data em questão.
+func ValidateMaxExpirationDate(b interface{}) error {
+	maxExpDate, _ := time.Parse("2006-01-02", "2025-02-21")
+
+	switch t := b.(type) {
+	case *models.BoletoRequest:
+		if t.Title.ExpireDateTime.After(maxExpDate) {
+			return models.NewErrorResponse("MPExpireDate", "Data de vencimento não pode ser maior que 21-02-2025")
 		}
 		return nil
 	default:

--- a/bradescoNetEmpresa/validations_test.go
+++ b/bradescoNetEmpresa/validations_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/mundipagg/boleto-api/models"
 	"github.com/mundipagg/boleto-api/test"
+	"github.com/mundipagg/boleto-api/validations"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
@@ -129,7 +130,7 @@ func Test_MaxDateExpirationBlockValidation_WhenTypeIsBoletoRequest(t *testing.T)
 	for _, fact := range expirationDateParameters {
 		expDate, _ := time.Parse("2006-01-02", fact.Input.(string))
 		request := newStubBoletoRequestBradescoNetEmpresa().WithExpirationDate(expDate).Build()
-		result := ValidateMaxExpirationDate(request)
+		result := validations.ValidateMaxExpirationDate(request)
 		assert.Equal(t, fact.Expected, result == nil, fmt.Sprintf("O resultado: %d não condiz com o esperado: %d, utilizando o input: %d", result, fact.Expected, fact.Input))
 	}
 }
@@ -137,6 +138,6 @@ func Test_MaxDateExpirationBlockValidation_WhenTypeIsBoletoRequest(t *testing.T)
 func Test_MaxDateExpirationBlockValidation_WhenTypeIsInvalid(t *testing.T) {
 
 	request := "Não é um boleto request"
-	result := ValidateMaxExpirationDate(request)
+	result := validations.ValidateMaxExpirationDate(request)
 	assert.IsType(t, models.ErrorResponse{}, result, fmt.Sprintf("O tipo do resultado: %T não condiz com o tipo esperado: %T", result, models.ErrorResponse{}))
 }

--- a/bradescoNetEmpresa/validations_test.go
+++ b/bradescoNetEmpresa/validations_test.go
@@ -1,0 +1,142 @@
+package bradescoNetEmpresa
+
+import (
+	"fmt"
+	"github.com/mundipagg/boleto-api/models"
+	"github.com/mundipagg/boleto-api/test"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+var agencyNumberParameters = []test.Parameter{
+	{Input: "1", Expected: true},
+	{Input: "12", Expected: true},
+	{Input: "123", Expected: true},
+	{Input: "1234", Expected: true},
+	{Input: "123A", Expected: true},
+	{Input: "", Expected: false},
+	{Input: "  ", Expected: false},
+	{Input: "123456789", Expected: false},
+}
+
+var accountNumberParameters = []test.Parameter{
+	{Input: "1", Expected: true},
+	{Input: "12", Expected: true},
+	{Input: "123", Expected: true},
+	{Input: "1234", Expected: true},
+	{Input: "123A", Expected: true},
+	{Input: "123456789", Expected: false},
+	{Input: "  ", Expected: false},
+	{Input: "", Expected: false},
+}
+
+var walletParameters = []test.Parameter{
+	{Input: uint16(4), Expected: true},
+	{Input: uint16(9), Expected: true},
+	{Input: uint16(19), Expected: true},
+	{Input: uint16(1), Expected: false},
+	{Input: uint16(6), Expected: false},
+	{Input: uint16(20), Expected: false},
+}
+
+var boletoTypeKeyParameters = []test.Parameter{
+	{Input: models.Title{BoletoType: ""}, Expected: true},
+	{Input: models.Title{BoletoType: "CH"}, Expected: true},
+	{Input: models.Title{BoletoType: "DM"}, Expected: true},
+	{Input: models.Title{BoletoType: "DS"}, Expected: true},
+	{Input: models.Title{BoletoType: "NP"}, Expected: true},
+	{Input: models.Title{BoletoType: "RC"}, Expected: true},
+	{Input: models.Title{BoletoType: "OUT"}, Expected: true},
+	{Input: models.Title{BoletoType: "A"}, Expected: false},
+	{Input: models.Title{BoletoType: "ABC"}, Expected: false},
+}
+
+var expirationDateParameters = []test.Parameter{
+	{Input: "2025-01-01", Expected: true},
+	{Input: "2025-02-20", Expected: true},
+	{Input: "2025-02-21", Expected: true},
+	{Input: "2025-02-22", Expected: false},
+	{Input: "2025-12-31", Expected: false},
+}
+
+func Test_AgencyValidation_WhenTypeIsBoletoRequest(t *testing.T) {
+
+	for _, fact := range agencyNumberParameters {
+		request := newStubBoletoRequestBradescoNetEmpresa().WithAgreementAgency(fact.Input.(string)).Build()
+		result := bradescoNetEmpresaValidateAgency(request)
+		assert.Equal(t, fact.Expected, result == nil, fmt.Sprintf("O resultado: %d não condiz com o esperado: %d, utilizando o input: %d", result, fact.Expected, fact.Input))
+	}
+}
+
+func Test_AgencyValidation_WhenTypeIsInvalid(t *testing.T) {
+
+	request := "Não é um boleto request"
+	result := bradescoNetEmpresaValidateAgency(request)
+	assert.IsType(t, models.ErrorResponse{}, result, fmt.Sprintf("O tipo do resultado: %T não condiz com o tipo esperado: %T", result, models.ErrorResponse{}))
+}
+
+func Test_AccountValidation_WhenTypeIsBoletoRequest(t *testing.T) {
+
+	for _, fact := range accountNumberParameters {
+		request := newStubBoletoRequestBradescoNetEmpresa().WithAgreementAccount(fact.Input.(string)).Build()
+		result := bradescoNetEmpresaValidateAccount(request)
+		assert.Equal(t, fact.Expected, result == nil, fmt.Sprintf("O resultado: %d não condiz com o esperado: %d, utilizando o input: %d", result, fact.Expected, fact.Input))
+	}
+}
+
+func Test_AccountValidation_WhenTypeIsInvalid(t *testing.T) {
+
+	request := "Não é um boleto request"
+	result := bradescoNetEmpresaValidateAccount(request)
+	assert.IsType(t, models.ErrorResponse{}, result, fmt.Sprintf("O tipo do resultado: %T não condiz com o tipo esperado: %T", result, models.ErrorResponse{}))
+}
+
+func Test_WalletValidation_WhenTypeIsBoletoRequest(t *testing.T) {
+
+	for _, fact := range walletParameters {
+		request := newStubBoletoRequestBradescoNetEmpresa().WithWallet(fact.Input.(uint16)).Build()
+		result := bradescoNetEmpresaValidateWallet(request)
+		assert.Equal(t, fact.Expected, result == nil, fmt.Sprintf("O resultado: %d não condiz com o esperado: %d, utilizando o input: %d", result, fact.Expected, fact.Input))
+	}
+}
+
+func Test_WalletValidation_WhenTypeIsInvalid(t *testing.T) {
+
+	request := "Não é um boleto request"
+	result := bradescoNetEmpresaValidateWallet(request)
+	assert.IsType(t, models.ErrorResponse{}, result, fmt.Sprintf("O tipo do resultado: %T não condiz com o tipo esperado: %T", result, models.ErrorResponse{}))
+}
+
+func Test_BoletoTypeValidation_WhenTypeIsBoletoRequest(t *testing.T) {
+
+	for _, fact := range boletoTypeKeyParameters {
+		request := newStubBoletoRequestBradescoNetEmpresa().WithBoletoType(fact.Input.(models.Title)).Build()
+		result := bradescoNetEmpresaBoletoTypeValidate(request)
+		assert.Equal(t, fact.Expected, result == nil, fmt.Sprintf("O resultado: %d não condiz com o esperado: %d, utilizando o input: %d", result, fact.Expected, fact.Input))
+	}
+}
+
+func Test_BoletoTypeValidation_WhenTypeIsInvalid(t *testing.T) {
+
+	request := "Não é um boleto request"
+	result := bradescoNetEmpresaBoletoTypeValidate(request)
+	assert.IsType(t, models.ErrorResponse{}, result, fmt.Sprintf("O tipo do resultado: %T não condiz com o tipo esperado: %T", result, models.ErrorResponse{}))
+}
+
+func Test_MaxDateExpirationBlockValidation_WhenTypeIsBoletoRequest(t *testing.T) {
+
+	for _, fact := range expirationDateParameters {
+		expDate, _ := time.Parse("2006-01-02", fact.Input.(string))
+		request := newStubBoletoRequestBradescoNetEmpresa().WithExpirationDate(expDate).Build()
+		result := ValidateMaxExpirationDate(request)
+		assert.Equal(t, fact.Expected, result == nil, fmt.Sprintf("O resultado: %d não condiz com o esperado: %d, utilizando o input: %d", result, fact.Expected, fact.Input))
+	}
+}
+
+func Test_MaxDateExpirationBlockValidation_WhenTypeIsInvalid(t *testing.T) {
+
+	request := "Não é um boleto request"
+	result := ValidateMaxExpirationDate(request)
+	assert.IsType(t, models.ErrorResponse{}, result, fmt.Sprintf("O tipo do resultado: %T não condiz com o tipo esperado: %T", result, models.ErrorResponse{}))
+}

--- a/bradescoShopFacil/bradescoShopFacil.go
+++ b/bradescoShopFacil/bradescoShopFacil.go
@@ -49,12 +49,14 @@ func New() bankBradescoShopFacil {
 	b.validate.Push(validations.ValidateExpireDate)
 	b.validate.Push(validations.ValidateBuyerDocumentNumber)
 	b.validate.Push(validations.ValidateRecipientDocumentNumber)
+
 	b.validate.Push(bradescoShopFacilValidateAgency)
 	b.validate.Push(bradescoShopFacilValidateAccount)
 	b.validate.Push(bradescoShopFacilValidateWallet)
 	b.validate.Push(bradescoShopFacilValidateAuth)
 	b.validate.Push(bradescoShopFacilValidateAgreement)
 	b.validate.Push(bradescoShopFacilBoletoTypeValidate)
+	b.validate.Push(ValidateMaxExpirationDate)
 	return b
 }
 

--- a/bradescoShopFacil/bradescoShopFacil.go
+++ b/bradescoShopFacil/bradescoShopFacil.go
@@ -47,6 +47,7 @@ func New() bankBradescoShopFacil {
 	}
 	b.validate.Push(validations.ValidateAmount)
 	b.validate.Push(validations.ValidateExpireDate)
+	b.validate.Push(validations.ValidateMaxExpirationDate)
 	b.validate.Push(validations.ValidateBuyerDocumentNumber)
 	b.validate.Push(validations.ValidateRecipientDocumentNumber)
 
@@ -56,7 +57,7 @@ func New() bankBradescoShopFacil {
 	b.validate.Push(bradescoShopFacilValidateAuth)
 	b.validate.Push(bradescoShopFacilValidateAgreement)
 	b.validate.Push(bradescoShopFacilBoletoTypeValidate)
-	b.validate.Push(ValidateMaxExpirationDate)
+
 	return b
 }
 

--- a/bradescoShopFacil/stub.go
+++ b/bradescoShopFacil/stub.go
@@ -1,0 +1,80 @@
+package bradescoShopFacil
+
+import (
+	"time"
+
+	"github.com/mundipagg/boleto-api/models"
+	"github.com/mundipagg/boleto-api/test"
+)
+
+const day = time.Hour * 24
+
+type stubBoletoRequestBradescoShopFacil struct {
+	test.StubBoletoRequest
+}
+
+//newStubBoletoRequestBradescoShopFacil Cria um novo StubBoletoRequest com valores default validáveis para o BradescoShopFacil
+func newStubBoletoRequestBradescoShopFacil() *stubBoletoRequestBradescoShopFacil {
+	expirationDate := time.Now().Add(5 * day)
+
+	base := test.NewStubBoletoRequest(models.Bradesco)
+	s := &stubBoletoRequestBradescoShopFacil{
+		StubBoletoRequest: *base,
+	}
+
+	s.Authentication = models.Authentication{
+		Username: "55555555555",
+		Password: "55555555555555555",
+	}
+
+	s.Agreement = models.Agreement{
+		AgreementNumber: 55555555,
+		Wallet:          25,
+		Agency:          "5555",
+		Account:         "55555",
+	}
+
+	s.Title = models.Title{
+		ExpireDateTime: expirationDate,
+		ExpireDate:     expirationDate.Format("2006-01-02"),
+		OurNumber:      12446688,
+		AmountInCents:  200,
+		DocumentNumber: "1234566",
+		Instructions:   "Senhor caixa, não receber após o vencimento",
+	}
+
+	s.Recipient = models.Recipient{
+		Name: "TESTE",
+		Document: models.Document{
+			Type:   "CNPJ",
+			Number: "00555555000109",
+		},
+		Address: models.Address{
+			Street:     "TESTE",
+			Number:     "111",
+			Complement: "TESTE",
+			ZipCode:    "11111111",
+			City:       "Teste",
+			District:   "",
+			StateCode:  "SP",
+		},
+	}
+
+	s.Buyer = models.Buyer{
+		Name: "Luke Skywalker",
+		Document: models.Document{
+			Type:   "CPF",
+			Number: "01234567890",
+		},
+		Address: models.Address{
+			Street:     "Mos Eisley Cantina",
+			Number:     "123",
+			Complement: "Apto",
+			ZipCode:    "20001-000",
+			City:       "Tatooine",
+			District:   "Tijuca",
+			StateCode:  "RJ",
+		},
+	}
+	return s
+}

--- a/bradescoShopFacil/validations.go
+++ b/bradescoShopFacil/validations.go
@@ -4,7 +4,6 @@ import (
 	"github.com/mundipagg/boleto-api/models"
 	"github.com/mundipagg/boleto-api/validations"
 	"strings"
-	"time"
 )
 
 func bradescoShopFacilValidateAgency(b interface{}) error {
@@ -78,23 +77,6 @@ func bradescoShopFacilBoletoTypeValidate(b interface{}) error {
 	case *models.BoletoRequest:
 		if len(t.Title.BoletoType) > 0 && bt[t.Title.BoletoType] == "" {
 			return models.NewErrorResponse("MP400", "espécie de boleto informada não existente")
-		}
-		return nil
-	default:
-		return validations.InvalidType(t)
-	}
-}
-
-// bradescoShopFacilMaxExpirationDateValidate O emissor Bradesco contém um bug na geração da linha digitável onde,
-// quando a data de vencimento é maior do que 21-02-2025 a linha digitável se torna inválida(O própio Bradesco não consegue ler a linha gerada) e não conseguimos gerar a visualização do boleto
-// Para evitarmos esse problema, adicionamos temporariamente essa trava que bloqueia a geração de boletos com data de vencimento após a data em questão.
-func ValidateMaxExpirationDate(b interface{}) error {
-	maxExpDate, _ := time.Parse("2006-01-02", "2025-02-21")
-
-	switch t := b.(type) {
-	case *models.BoletoRequest:
-		if t.Title.ExpireDateTime.After(maxExpDate) {
-			return models.NewErrorResponse("MPExpireDate", "Data de vencimento não pode ser maior que 21-02-2025")
 		}
 		return nil
 	default:

--- a/bradescoShopFacil/validations_test.go
+++ b/bradescoShopFacil/validations_test.go
@@ -1,0 +1,186 @@
+package bradescoShopFacil
+
+import (
+	"fmt"
+	"github.com/mundipagg/boleto-api/models"
+	"github.com/mundipagg/boleto-api/test"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+var agencyNumberParameters = []test.Parameter{
+	{Input: "1", Expected: true},
+	{Input: "12", Expected: true},
+	{Input: "123", Expected: true},
+	{Input: "1234", Expected: true},
+	{Input: "123A", Expected: true},
+	{Input: "", Expected: false},
+	{Input: "  ", Expected: false},
+	{Input: "123456789", Expected: false},
+}
+
+var accountNumberParameters = []test.Parameter{
+	{Input: "1", Expected: true},
+	{Input: "12", Expected: true},
+	{Input: "123", Expected: true},
+	{Input: "1234", Expected: true},
+	{Input: "123A", Expected: true},
+	{Input: "123456789", Expected: true},
+	{Input: "  ", Expected: true},
+	{Input: "", Expected: false},
+}
+
+var walletParameters = []test.Parameter{
+	{Input: uint16(25), Expected: true},
+	{Input: uint16(26), Expected: true},
+	{Input: uint16(10), Expected: false},
+	{Input: uint16(20), Expected: false},
+	{Input: uint16(40), Expected: false},
+	{Input: uint16(50), Expected: false},
+}
+
+var authenticationParameters = []test.Parameter{
+	{Input: models.Authentication{Username: "Usuario", Password: "Senha"}, Expected: true},
+	{Input: models.Authentication{Username: "   ", Password: "Senha"}, Expected: false},
+	{Input: models.Authentication{Username: "", Password: "Senha"}, Expected: false},
+	{Input: models.Authentication{Username: "Usuario", Password: "   "}, Expected: false},
+	{Input: models.Authentication{Username: "Usuario", Password: ""}, Expected: false},
+	{Input: models.Authentication{Username: "", Password: ""}, Expected: false},
+}
+
+var agreementNumberParameters = []test.Parameter{
+	{Input: uint(1), Expected: true},
+	{Input: uint(4), Expected: true},
+	{Input: uint(0), Expected: false},
+}
+
+var boletoTypeKeyParameters = []test.Parameter{
+	{Input: models.Title{BoletoType: ""}, Expected: true},
+	{Input: models.Title{BoletoType: "DM"}, Expected: true},
+	{Input: models.Title{BoletoType: "NP"}, Expected: true},
+	{Input: models.Title{BoletoType: "RC"}, Expected: true},
+	{Input: models.Title{BoletoType: "DS"}, Expected: true},
+	{Input: models.Title{BoletoType: "OUT"}, Expected: true},
+	{Input: models.Title{BoletoType: "A"}, Expected: false},
+	{Input: models.Title{BoletoType: "ABC"}, Expected: false},
+}
+
+var expirationDateParameters = []test.Parameter{
+	{Input: "2025-01-01", Expected: true},
+	{Input: "2025-02-20", Expected: true},
+	{Input: "2025-02-21", Expected: true},
+	{Input: "2025-02-22", Expected: false},
+	{Input: "2025-12-31", Expected: false},
+}
+
+func Test_AgencyValidation_WhenTypeIsBoletoRequest(t *testing.T) {
+
+	for _, fact := range agencyNumberParameters {
+		request := newStubBoletoRequestBradescoShopFacil().WithAgreementAgency(fact.Input.(string)).Build()
+		result := bradescoShopFacilValidateAgency(request)
+		assert.Equal(t, fact.Expected, result == nil, fmt.Sprintf("O resultado: %d não condiz com o esperado: %d, utilizando o input: %d", result, fact.Expected, fact.Input))
+	}
+}
+
+func Test_AgencyValidation_WhenTypeIsInvalid(t *testing.T) {
+
+	request := "Não é um boleto request"
+	result := bradescoShopFacilValidateAgency(request)
+	assert.IsType(t, models.ErrorResponse{}, result, fmt.Sprintf("O tipo do resultado: %T não condiz com o tipo esperado: %T", result, models.ErrorResponse{}))
+}
+
+func Test_AccountValidation_WhenTypeIsBoletoRequest(t *testing.T) {
+
+	for _, fact := range accountNumberParameters {
+		request := newStubBoletoRequestBradescoShopFacil().WithAgreementAccount(fact.Input.(string)).Build()
+		result := bradescoShopFacilValidateAccount(request)
+		assert.Equal(t, fact.Expected, result == nil, fmt.Sprintf("O resultado: %d não condiz com o esperado: %d, utilizando o input: %d", result, fact.Expected, fact.Input))
+	}
+}
+
+func Test_AccountValidation_WhenTypeIsInvalid(t *testing.T) {
+
+	request := "Não é um boleto request"
+	result := bradescoShopFacilValidateAccount(request)
+	assert.IsType(t, models.ErrorResponse{}, result, fmt.Sprintf("O tipo do resultado: %T não condiz com o tipo esperado: %T", result, models.ErrorResponse{}))
+}
+
+func Test_WalletValidation_WhenTypeIsBoletoRequest(t *testing.T) {
+
+	for _, fact := range walletParameters {
+		request := newStubBoletoRequestBradescoShopFacil().WithWallet(fact.Input.(uint16)).Build()
+		result := bradescoShopFacilValidateWallet(request)
+		assert.Equal(t, fact.Expected, result == nil, fmt.Sprintf("O resultado: %d não condiz com o esperado: %d, utilizando o input: %d", result, fact.Expected, fact.Input))
+	}
+}
+
+func Test_WalletValidation_WhenTypeIsInvalid(t *testing.T) {
+
+	request := "Não é um boleto request"
+	result := bradescoShopFacilValidateWallet(request)
+	assert.IsType(t, models.ErrorResponse{}, result, fmt.Sprintf("O tipo do resultado: %T não condiz com o tipo esperado: %T", result, models.ErrorResponse{}))
+}
+
+func Test_AuthenticationValidation_WhenTypeIsBoletoRequest(t *testing.T) {
+	for _, fact := range authenticationParameters {
+		request := newStubBoletoRequestBradescoShopFacil().WithAuthentication(fact.Input.(models.Authentication)).Build()
+		result := bradescoShopFacilValidateAuth(request)
+		assert.Equal(t, fact.Expected, result == nil, fmt.Sprintf("O resultado: %d não condiz com o esperado: %d, utilizando o input: %d", result, fact.Expected, fact.Input))
+	}
+}
+
+func Test_AuthenticationValidation_WhenTypeIsInvalid(t *testing.T) {
+
+	request := "Não é um boleto request"
+	result := bradescoShopFacilValidateAuth(request)
+	assert.IsType(t, models.ErrorResponse{}, result, fmt.Sprintf("O tipo do resultado: %T não condiz com o tipo esperado: %T", result, models.ErrorResponse{}))
+}
+
+func Test_AgreementNumberValidation_WhenTypeIsBoletoRequest(t *testing.T) {
+	for _, fact := range agreementNumberParameters {
+		request := newStubBoletoRequestBradescoShopFacil().WithAgreementNumber(fact.Input.(uint)).Build()
+		result := bradescoShopFacilValidateAgreement(request)
+		assert.Equal(t, fact.Expected, result == nil, fmt.Sprintf("O resultado: %d não condiz com o esperado: %d, utilizando o input: %d", result, fact.Expected, fact.Input))
+	}
+}
+
+func Test_AgreementNumberValidation_WhenTypeIsInvalid(t *testing.T) {
+
+	request := "Não é um boleto request"
+	result := bradescoShopFacilValidateAgreement(request)
+	assert.IsType(t, models.ErrorResponse{}, result, fmt.Sprintf("O tipo do resultado: %T não condiz com o tipo esperado: %T", result, models.ErrorResponse{}))
+}
+
+func Test_BoletoTypeValidation_WhenTypeIsBoletoRequest(t *testing.T) {
+
+	for _, fact := range boletoTypeKeyParameters {
+		request := newStubBoletoRequestBradescoShopFacil().WithBoletoType(fact.Input.(models.Title)).Build()
+		result := bradescoShopFacilBoletoTypeValidate(request)
+		assert.Equal(t, fact.Expected, result == nil, fmt.Sprintf("O resultado: %d não condiz com o esperado: %d, utilizando o input: %d", result, fact.Expected, fact.Input))
+	}
+}
+
+func Test_BoletoTypeValidation_WhenTypeIsInvalid(t *testing.T) {
+
+	request := "Não é um boleto request"
+	result := bradescoShopFacilBoletoTypeValidate(request)
+	assert.IsType(t, models.ErrorResponse{}, result, fmt.Sprintf("O tipo do resultado: %T não condiz com o tipo esperado: %T", result, models.ErrorResponse{}))
+}
+
+func Test_MaxDateExpirationBlockValidation_WhenTypeIsBoletoRequest(t *testing.T) {
+
+	for _, fact := range expirationDateParameters {
+		expDate, _ := time.Parse("2006-01-02", fact.Input.(string))
+		request := newStubBoletoRequestBradescoShopFacil().WithExpirationDate(expDate).Build()
+		result := ValidateMaxExpirationDate(request)
+		assert.Equal(t, fact.Expected, result == nil, fmt.Sprintf("O resultado: %d não condiz com o esperado: %d, utilizando o input: %d", result, fact.Expected, fact.Input))
+	}
+}
+
+func Test_MaxDateExpirationBlockValidation_WhenTypeIsInvalid(t *testing.T) {
+
+	request := "Não é um boleto request"
+	result := ValidateMaxExpirationDate(request)
+	assert.IsType(t, models.ErrorResponse{}, result, fmt.Sprintf("O tipo do resultado: %T não condiz com o tipo esperado: %T", result, models.ErrorResponse{}))
+}

--- a/bradescoShopFacil/validations_test.go
+++ b/bradescoShopFacil/validations_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/mundipagg/boleto-api/models"
 	"github.com/mundipagg/boleto-api/test"
+	"github.com/mundipagg/boleto-api/validations"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
@@ -173,7 +174,7 @@ func Test_MaxDateExpirationBlockValidation_WhenTypeIsBoletoRequest(t *testing.T)
 	for _, fact := range expirationDateParameters {
 		expDate, _ := time.Parse("2006-01-02", fact.Input.(string))
 		request := newStubBoletoRequestBradescoShopFacil().WithExpirationDate(expDate).Build()
-		result := ValidateMaxExpirationDate(request)
+		result := validations.ValidateMaxExpirationDate(request)
 		assert.Equal(t, fact.Expected, result == nil, fmt.Sprintf("O resultado: %d não condiz com o esperado: %d, utilizando o input: %d", result, fact.Expected, fact.Input))
 	}
 }
@@ -181,6 +182,6 @@ func Test_MaxDateExpirationBlockValidation_WhenTypeIsBoletoRequest(t *testing.T)
 func Test_MaxDateExpirationBlockValidation_WhenTypeIsInvalid(t *testing.T) {
 
 	request := "Não é um boleto request"
-	result := ValidateMaxExpirationDate(request)
+	result := validations.ValidateMaxExpirationDate(request)
 	assert.IsType(t, models.ErrorResponse{}, result, fmt.Sprintf("O tipo do resultado: %T não condiz com o tipo esperado: %T", result, models.ErrorResponse{}))
 }

--- a/log/log.go
+++ b/log/log.go
@@ -25,16 +25,17 @@ var Operation string
 //Recipient o nome do banco
 var Recipient string
 
-//Log struct com os elemtos do log
+//Log struct com os elementos do log
 type Log struct {
-	Operation   string
-	Recipient   string
-	RequestKey  string
-	BankName    string
-	IPAddress   string
-	ServiceUser string
-	NossoNumero string
-	logger      tracer.Logger
+	Operation      string
+	Recipient      string
+	PayeeGuarantor string
+	RequestKey     string
+	BankName       string
+	IPAddress      string
+	ServiceUser    string
+	NossoNumero    string
+	logger         tracer.Logger
 }
 
 //Install instala o "servico" de log do SEQ
@@ -292,6 +293,10 @@ func (l *Log) defaultProperties(messageType string, content interface{}) LogEntr
 		"BankName":    l.BankName,
 		"ServiceUser": l.ServiceUser,
 		"IPAddress":   l.IPAddress,
+	}
+
+	if len(l.PayeeGuarantor) > 0 {
+		props["PayeeGuarantor"] = l.PayeeGuarantor
 	}
 
 	for k, v := range l.basicProperties(messageType) {

--- a/models/agreement.go
+++ b/models/agreement.go
@@ -22,7 +22,7 @@ type Agreement struct {
 func (a *Agreement) IsAgencyValid() error {
 	re := regexp.MustCompile("(\\D+)")
 	ag := re.ReplaceAllString(a.Agency, "")
-	if len(ag) < 5 && len(ag) > 0 {
+	if len(ag) > 0 && len(ag) < 5 {
 		a.Agency = util.PadLeft(ag, "0", 4)
 		return nil
 	}
@@ -44,7 +44,7 @@ func (a *Agreement) CalculateAgencyDigit(digitCalculator func(agency string) str
 func (a *Agreement) IsAccountValid(accountLength int) error {
 	re := regexp.MustCompile("(\\D+)")
 	ac := re.ReplaceAllString(a.Account, "")
-	if len(ac) < accountLength+1 && len(ac) > 0 {
+	if len(ac) > 0 && len(ac) < accountLength+1 {
 		a.Account = util.PadLeft(ac, "0", uint(accountLength))
 		return nil
 	}

--- a/test/stub.go
+++ b/test/stub.go
@@ -49,6 +49,16 @@ func (s *StubBoletoRequest) WithAgreementAccount(account string) *StubBoletoRequ
 	return s
 }
 
+func (s *StubBoletoRequest) WithWallet(wallet uint16) *StubBoletoRequest {
+	s.Agreement.Wallet = wallet
+	return s
+}
+
+func (s *StubBoletoRequest) WithAuthentication(authentication models.Authentication) *StubBoletoRequest {
+	s.Authentication = authentication
+	return s
+}
+
 func (s *StubBoletoRequest) WithAmountInCents(amount uint64) *StubBoletoRequest {
 	s.Title.AmountInCents = amount
 	return s
@@ -81,6 +91,12 @@ func (s *StubBoletoRequest) WithAcceptDivergentAmount(accepted bool) *StubBoleto
 	}
 
 	s.Title.Rules.AcceptDivergentAmount = accepted
+	return s
+}
+
+func (s *StubBoletoRequest) WithBoletoType(title models.Title) *StubBoletoRequest {
+	s.Title.BoletoType = title.BoletoType
+	s.Title.BoletoTypeCode = title.BoletoTypeCode
 	return s
 }
 


### PR DESCRIPTION
# Descrição

### Tarefa [BPROC-366](https://mundipagg.atlassian.net/secure/RapidBoard.jspa?rapidView=76&projectKey=CA&modal=detail&selectedIssue=CA-427) 

Este PR tem como objetivos:

1 - Adicionar uma validação na geração de boletos Bradesco NetEmpresa e Bradesco ShopFacil que não permita a emissão caso a data de vencimento seja maior que 21-02-2022. Essa alteração se deve a um bug existente no Bradesco que ao gerar um boleto com a data de vencimento maior do que a especificada a linha digitável se torna inválida, não sendo lida/aceita nem mesmo pelo próprio Bradesco, já no lado Pagar.me, não é possível gerar a visualização do mesmo.

2 - Adicionar a propriedade PayeeGuarantor nos logs caso o boleto gerado contenha os dados do sacador avalista.

### Tipos de alterações

- [x] Correção de bug 
- [ ] Nova feature 
- [x] Alteração ou remoção de funcionalidade existente
- [ ] Atualização de documentação

## Testes

### Adição de Validação NetEmpresa e ShopFácil

### Teste Local

Foram enviados requests com a data de vencimento do boleto menor igual e maior a data 21-02-2025, de forma que apenas o último caso deveria falhar.

**20-02-2025**
![image](https://user-images.githubusercontent.com/62444301/160189676-13da6bfc-4c06-4279-aa3c-4ed543f80234.png)

![image](https://user-images.githubusercontent.com/62444301/160189833-5a2b7f40-5131-4e33-b5ad-bdf93ea26267.png)

**21-02-2025**
![image](https://user-images.githubusercontent.com/62444301/160189171-e95c6c72-8a1a-422b-9b29-0f88ec8b8efc.png)

![image](https://user-images.githubusercontent.com/62444301/160189886-809e636a-1c1c-49e2-8f9e-920b01454fec.png)

**22-02-2025**
![image](https://user-images.githubusercontent.com/62444301/160189342-a5b23b80-544c-4837-9aef-985ed01359f1.png)

![image](https://user-images.githubusercontent.com/62444301/160190028-74c5299b-b589-45a4-bfbe-9d7dddedf696.png)

### Teste Staging

**20-02-2025**
![image](https://user-images.githubusercontent.com/62444301/160399370-7406d8d9-7043-419b-ae9c-0de5029aeddd.png)

![image](https://user-images.githubusercontent.com/62444301/160402762-6a5b8228-7818-4a47-a791-d3d7ad78624e.png)

**21-02-2025**
![image](https://user-images.githubusercontent.com/62444301/160399479-d14b02f3-3a7d-4da3-b6eb-2ecc8479d7e4.png)

![image](https://user-images.githubusercontent.com/62444301/160402867-31e6d112-6825-4b3c-b41c-ca94a751b745.png)

**22-02-2025**
![image](https://user-images.githubusercontent.com/62444301/160399586-fc5cd400-476a-431e-a5e7-7c4315e9a6e1.png)

![image](https://user-images.githubusercontent.com/62444301/160402947-fc885003-b776-4be6-abe7-118bce2b0c88.png)

## Adição da propriedade PayeeGuarantor nos logs

### Teste Local

Enviamos requests de alguns bancos emissores com e sem os dados de PayeeGuarantor, de forma que quando informado, deve ser mostrado a propriedade no logs caso contrário não deve existir tal propriedade.

**Banco do Brasil**

![image](https://user-images.githubusercontent.com/62444301/160191140-64f6af6e-028f-4ad0-9593-df528107f07b.png)
![image](https://user-images.githubusercontent.com/62444301/160191530-1dd06c34-facf-46f0-b8b0-44a621955b11.png)

![image](https://user-images.githubusercontent.com/62444301/160191740-a6d84c70-f0b8-44e7-b30a-84bafeed3d40.png)
![image](https://user-images.githubusercontent.com/62444301/160191796-8813f621-df30-4f3e-ae69-e54eb340180f.png)

**Caixa**

![image](https://user-images.githubusercontent.com/62444301/160192472-4cedd115-1a25-421c-8e6c-aaa1304a029b.png)
![image](https://user-images.githubusercontent.com/62444301/160192518-d0114915-411b-414f-9f99-516d073e5de4.png)

![image](https://user-images.githubusercontent.com/62444301/160192562-ac056daa-af72-4ec3-9848-2244cccc09b4.png)
![image](https://user-images.githubusercontent.com/62444301/160192645-6927524d-0c99-4f04-ac61-3415bc35d0af.png)

### Teste Local

**Banco do Brasil**

![image](https://user-images.githubusercontent.com/62444301/160403665-a3229580-bfe7-4954-b77b-955ba10035e8.png)
![image](https://user-images.githubusercontent.com/62444301/160403835-c352d481-7fa7-48be-8d71-6d40962ecb85.png)

![image](https://user-images.githubusercontent.com/62444301/160403963-09fda40b-4bd1-45a7-8604-8b4402779314.png)
![image](https://user-images.githubusercontent.com/62444301/160404033-c9ca4fd3-67cf-47c1-8662-b4b25d505c2b.png)

**Caixa**

![image](https://user-images.githubusercontent.com/62444301/160404142-3a442376-432e-4f83-9aad-68b49433ccc7.png)
![image](https://user-images.githubusercontent.com/62444301/160404335-037fe52f-fbaa-4ba5-9d59-382d2ee34d51.png)

![image](https://user-images.githubusercontent.com/62444301/160404412-cf33f03e-4101-45a7-9a4e-d366b77faabb.png)
![image](https://user-images.githubusercontent.com/62444301/160404515-15083bb2-a961-43c0-81f6-82dc706a9c5d.png)

## Checklist

- [X] Associei corretamente a Tarefa do Board ao Pull Request.
- [X] Meu código segue as diretrizes desse projeto.
- [X] Eu revisei meu próprio código.
- [X] Eu comentei meu código em áreas particulares de difícil compreensão.
- [ ] Eu atualizei a documentação de acordo com as mudanças realizadas.
- [X] Meu código não gerou novos warnings.
- [X] Eu adicionei testes que provam que minha correção é efetiva ou que a nova feature funciona.
- [X] Testes novos e existentes passam localmente com minhas alterações. 
- [ ] Testes novos e existentes passam em staging com minhas alterações. 
- [X] Qualquer dependência dessa alteração já foi realizada (deploy, configuração em todos os ambientes, etc).
