### PR TITLE
[BPROC-417] - Não enviar Endereço do Pagador para Caixa

### DIFF
--- a/boleto/templateCaixa.go
+++ b/boleto/templateCaixa.go
@@ -412,8 +412,13 @@ const boletoFormCaixa = `
                             <td><span class="text" id="buyer_document"><b>CNPJ/CPF: </b>&nbsp;{{fmtDoc .View.Boleto.Buyer.Document}}</span></td>
                         </tr>
                         <tr>
+                        {{if .View.Boleto.Buyer.HasAddress}}
                             <td><span class="text" id="buyer_address"><b>Endereço: </b>&nbsp;{{.View.Boleto.Buyer.Address.Street}}&nbsp;{{.View.Boleto.Buyer.Address.Number}}, {{.View.Boleto.Buyer.Address.District}} - {{.View.Boleto.Buyer.Address.City}}, {{.View.Boleto.Buyer.Address.StateCode}} - {{.View.Boleto.Buyer.Address.ZipCode}}</span></td>
                             <td>&nbsp;</td>
+                        {{else}}
+                        <td><span class="text" id="buyer_address"><b>Endereço: </b>&nbsp;&nbsp;</span></td>
+                            <td>&nbsp;</td>
+                        {{end}}
                         </tr>
                         <tr>
                         {{if .View.Boleto.HasPayeeGuarantor}}

--- a/caixa/caixa_test.go
+++ b/caixa/caixa_test.go
@@ -149,7 +149,7 @@ func TestTemplateRequestCaixa_Instructions_ParseSuccessful(t *testing.T) {
 
 func TestTemplateRequestCaixa_WhenRequestV1_ParseSuccessful(t *testing.T) {
 	f := flow.NewFlow()
-	input := newStubBoletoRequestCaixa().Build()
+	input := newStubBoletoRequestCaixa().WithBuyerAddress().Build()
 
 	b := fmt.Sprintf("%v", f.From("message://?source=inline", input, getRequestCaixa(), tmpl.GetFuncMaps()).GetBody())
 
@@ -172,7 +172,7 @@ func TestTemplateRequestCaixa_WhenRequestV1_ParseSuccessful(t *testing.T) {
 
 func TestTemplateRequestCaixa_WhenRequestWithStrictRulesV2_ParseSuccessful(t *testing.T) {
 	f := flow.NewFlow()
-	input := newStubBoletoRequestCaixa().WithStrictRules().Build()
+	input := newStubBoletoRequestCaixa().WithBuyerAddress().WithStrictRules().Build()
 
 	b := fmt.Sprintf("%v", f.From("message://?source=inline", input, getRequestCaixa(), tmpl.GetFuncMaps()).GetBody())
 
@@ -191,7 +191,7 @@ func TestTemplateRequestCaixa_WhenRequestWithStrictRulesV2_ParseSuccessful(t *te
 
 func TestTemplateRequestCaixa_WhenRequestWithFlexRulesV2_ParseSuccessful(t *testing.T) {
 	f := flow.NewFlow()
-	input := newStubBoletoRequestCaixa().WithFlexRules().Build()
+	input := newStubBoletoRequestCaixa().WithBuyerAddress().WithFlexRules().Build()
 
 	b := fmt.Sprintf("%v", f.From("message://?source=inline", input, getRequestCaixa(), tmpl.GetFuncMaps()).GetBody())
 
@@ -387,4 +387,24 @@ func TestTemplateRequestCaixa_WhenRequestWithoutPayeeGuarantor_HasNotPayeeGuaran
 	nodeContent := test.GetNode(b, "SACADOR_AVALISTA")
 
 	assert.Contains(t, nodeContent, "", "Não deve haver o nó PayeeGuarantor")
+}
+
+func TestTemplateRequestCaixa_WhenRequestWithoutBuyerAddress_HasNotBuyerAddressNode(t *testing.T) {
+	f := flow.NewFlow()
+	input := newStubBoletoRequestCaixa().Build()
+
+	b := fmt.Sprintf("%v", f.From("message://?source=inline", input, getRequestCaixa(), tmpl.GetFuncMaps()).GetBody())
+	nodeContent := test.GetNode(b, "ENDERECO")
+
+	assert.Empty(t, nodeContent, "Não deve haver o nó Address no Buyer")
+}
+
+func TestTemplateRequestCaixa_WhenRequestWithBuyerAddress_HasBuyerAddressNode(t *testing.T) {
+	f := flow.NewFlow()
+	input := newStubBoletoRequestCaixa().WithBuyerAddress().Build()
+
+	b := fmt.Sprintf("%v", f.From("message://?source=inline", input, getRequestCaixa(), tmpl.GetFuncMaps()).GetBody())
+	nodeContent := test.GetNode(b, "ENDERECO")
+
+	assert.NotEmpty(t, nodeContent, "Deve haver o nó Address no Buyer")
 }

--- a/caixa/request.go
+++ b/caixa/request.go
@@ -92,6 +92,7 @@ const requestToCaixa = `
 					 	   <CNPJ>{{.Buyer.Document.Number}}</CNPJ>
                      <RAZAO_SOCIAL>{{truncateOnly (clearStringCaixa .Buyer.Name) 40}}</RAZAO_SOCIAL>
 					   {{end}}
+                  {{if .Buyer.HasAddress}}
                      <ENDERECO>
                         <LOGRADOURO>{{truncateOnly (joinSpace (clearStringCaixa .Buyer.Address.Street) (clearStringCaixa .Buyer.Address.Number) (clearStringCaixa .Buyer.Address.Complement)) 40}}</LOGRADOURO>
                         <BAIRRO>{{truncateOnly (clearStringCaixa .Buyer.Address.District) 15}}</BAIRRO>
@@ -99,6 +100,7 @@ const requestToCaixa = `
                         <UF>{{truncateOnly (clearStringCaixa .Buyer.Address.StateCode) 2}}</UF>
                         <CEP>{{truncateOnly (replace (clearStringCaixa .Buyer.Address.ZipCode) "-" "") 8}}</CEP>
                      </ENDERECO>
+                  {{end}}
                   </PAGADOR>
                   {{if .HasPayeeGuarantor}}
                      <SACADOR_AVALISTA>

--- a/caixa/stub.go
+++ b/caixa/stub.go
@@ -51,15 +51,19 @@ func newStubBoletoRequestCaixa() *stubBoletoRequestCaixa {
 			Type:   "CPF",
 			Number: "12312312312",
 		},
-		Address: models.Address{
-			Street:     "Rua da Assunção de Sá",
-			Number:     "123",
-			Complement: "Seção A, s 02",
-			ZipCode:    "20520051",
-			City:       "Belém do Pará",
-			District:   "Açaí",
-			StateCode:  "PA",
-		},
+	}
+	return s
+}
+
+func (s *stubBoletoRequestCaixa) WithBuyerAddress() *stubBoletoRequestCaixa {
+	s.Buyer.Address = models.Address{
+		Street:     "Rua da Assunção de Sá",
+		Number:     "123",
+		Complement: "Seção A, s 02",
+		ZipCode:    "20520051",
+		City:       "Belém do Pará",
+		District:   "Açaí",
+		StateCode:  "PA",
 	}
 	return s
 }

--- a/models/buyer.go
+++ b/models/buyer.go
@@ -7,3 +7,8 @@ type Buyer struct {
 	Document Document `json:"document,omitempty"`
 	Address  Address  `json:"address,omitempty"`
 }
+
+//HasAddress verify if Adress is not empty
+func (b Buyer) HasAddress() bool {
+	return b.Address != Address{}
+}


### PR DESCRIPTION
# Descrição

### Tarefa [BPROC-417](https://mundipagg.atlassian.net/secure/RapidBoard.jspa?rapidView=76&projectKey=CA&modal=detail&selectedIssue=BPROC-417) 

Este PR tem a finalidade de condicionar o envio do endereço do pagador para a Caixa quando o request vem da superbowleto.  Além da exibição desse endereço no layout.

### Tipos de alterações

- [ ] Correção de bug 
- [x] Nova feature 
- [ ] Alteração ou remoção de funcionalidade existente
- [ ] Atualização de documentação

## Testes

Recebimento do Buyer sem o endereço pela boleto-api

![image](https://user-images.githubusercontent.com/88195864/160703666-e528114f-d498-4d72-924e-896a8140780b.png)

Request do Buyer sem o endereço para a Caixa

![image](https://user-images.githubusercontent.com/88195864/160703845-b4d79241-6348-491e-8705-13742b10e95f.png)

O endereço não é preenchido se o nó não for enviado para a boleto-api

![image](https://user-images.githubusercontent.com/88195864/160704467-802e3446-a985-4a8a-acf6-f2aa6dc3a92d.png)

## Checklist

- [x] Associei corretamente a Tarefa do Board ao Pull Request.
- [x] Meu código segue as diretrizes desse projeto.
- [x] Eu revisei meu próprio código.
- [x] Eu comentei meu código em áreas particulares de difícil compreensão.
- [x] Eu atualizei a documentação de acordo com as mudanças realizadas.
- [x] Meu código não gerou novos warnings.
- [x] Eu adicionei testes que provam que minha correção é efetiva ou que a nova feature funciona.
- [x] Testes novos e existentes passam localmente com minhas alterações. 
- [x] Testes novos e existentes passam em staging com minhas alterações. 
- [x] Qualquer dependência dessa alteração já foi realizada (deploy, configuração em todos os ambientes, etc).
