### PR TITLE
[BPROC-463] - send the document number on request to banco do brasil

### DIFF
--- a/bb/request_test.go
+++ b/bb/request_test.go
@@ -1,27 +1,12 @@
 package bb
 
-/*
-@author Philippe Moneda
-@date 10/04/2017
-Descreve o padrão de mensagem para Boletos do Banco do Brasil
-*/
-const authBB = `## Content-Type:application/x-www-form-urlencoded
-## Cache-Control:no-cache
-## Authorization:Basic {{base64 (concat .Authentication.Username ":" .Authentication.Password)}}
-grant_type=client_credentials&scope=cobranca.registro-boletos`
+import (
+	"testing"
 
-const authLetterBBResponse = `
-{
-	"access_token":"{{authToken}}"	
-}
-`
+	"github.com/stretchr/testify/assert"
+)
 
-//GetBBAuthLetters retorna as cartas de envio e retorno de autencação do BB
-func GetBBAuthLetters() (string, string) {
-	return authBB, authLetterBBResponse
-}
-
-const registerBoleto = `
+const requestExpected = `
  ## SOAPACTION:registrarBoleto
  ##	Authorization:Bearer {{.Authentication.AuthorizationToken}}
  ## Content-Type:text/xml; charset=utf-8
@@ -61,29 +46,8 @@ const registerBoleto = `
 </soapenv:Envelope>
  `
 
-//getRequest retorna o template do Banco do Brasil
-func getRequest() string {
-	return registerBoleto
-}
+func Test_GivenTheGetRequestMethodWasCalled_ThenItShouldCorrectlyGetTheRequestTemplate(t *testing.T) {
+	result := getRequest()
 
-const registerBoletoBBResponse = `
-
-<?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
-<SOAP-ENV:Body>
-	<ns0:resposta xmlns:ns0="http://www.tibco.com/schemas/bws_registro_cbr/Recursos/XSD/Schema.xsd">
-		<ns0:siglaSistemaMensagem />
-		<ns0:codigoRetornoPrograma>{{returnCode}}</ns0:codigoRetornoPrograma>
-		<ns0:nomeProgramaErro>{{errorCode}}</ns0:nomeProgramaErro>
-		<ns0:textoMensagemErro>{{errorMessage}}</ns0:textoMensagemErro>
-		<ns0:linhaDigitavel>{{digitableLine}}</ns0:linhaDigitavel>
-		<ns0:codigoBarraNumerico>{{barcodeNumber}}</ns0:codigoBarraNumerico>				
-	</ns0:resposta>
-</SOAP-ENV:Body>
-</SOAP-ENV:Envelope>
-
-`
-
-func getResponseBB() string {
-	return registerBoletoBBResponse
+	assert.Equal(t, requestExpected, result, "Deve trazer corretamente o template de request")
 }

--- a/bb/stub_builder.go
+++ b/bb/stub_builder.go
@@ -1,0 +1,51 @@
+package bb
+
+import (
+	"github.com/mundipagg/boleto-api/models"
+	"github.com/mundipagg/boleto-api/test"
+)
+
+type stubBoletoRequestBB struct {
+	test.StubBoletoRequest
+}
+
+func newStubBoletoRequestBB() *stubBoletoRequestBB {
+	base := test.NewStubBoletoRequest(models.BancoDoBrasil)
+
+	s := &stubBoletoRequestBB{
+		StubBoletoRequest: *base,
+	}
+
+	s.Agreement = models.Agreement{}
+	s.Title = models.Title{}
+	s.Recipient = models.Recipient{}
+	s.Buyer = models.Buyer{}
+	s.Buyer.Address = models.Address{}
+
+	return s
+}
+
+func (s *stubBoletoRequestBB) WithAgreement(agreement models.Agreement) *stubBoletoRequestBB {
+	s.Agreement = agreement
+	return s
+}
+
+func (s *stubBoletoRequestBB) WithTitle(title models.Title) *stubBoletoRequestBB {
+	s.Title = title
+	return s
+}
+
+func (s *stubBoletoRequestBB) WithRecipient(recipient models.Recipient) *stubBoletoRequestBB {
+	s.Recipient = recipient
+	return s
+}
+
+func (s *stubBoletoRequestBB) WithBuyer(buyer models.Buyer) *stubBoletoRequestBB {
+	s.Buyer = buyer
+	return s
+}
+
+func (s *stubBoletoRequestBB) WithBuyerAddress(address models.Address) *stubBoletoRequestBB {
+	s.Buyer.Address = address
+	return s
+}

--- a/bb/validations.go
+++ b/bb/validations.go
@@ -1,6 +1,8 @@
 package bb
 
 import (
+	"fmt"
+
 	"github.com/mundipagg/boleto-api/models"
 	"github.com/mundipagg/boleto-api/validations"
 )
@@ -81,7 +83,12 @@ func bbValidateTitleInstructions(b interface{}) error {
 func bbValidateTitleDocumentNumber(b interface{}) error {
 	switch t := b.(type) {
 	case *models.BoletoRequest:
-		return t.Title.ValidateDocumentNumber()
+		maxAllowedLength := 15
+		if len(t.Title.DocumentNumber) > maxAllowedLength {
+			message := fmt.Sprintf("O campo documentNumber do título ultrapassou o limite permitido de %d caracteres", maxAllowedLength)
+			return models.NewErrorResponse("MP400", message)
+		}
+		return nil
 	default:
 		return validations.InvalidType(t)
 	}

--- a/bb/validations_test.go
+++ b/bb/validations_test.go
@@ -1,0 +1,48 @@
+package bb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/mundipagg/boleto-api/models"
+	"github.com/mundipagg/boleto-api/test"
+	"github.com/stretchr/testify/assert"
+)
+
+var boletoRequestParameters = []test.Parameter{
+	{
+		Line:     0,
+		Input:    newStubBoletoRequestBB().Build(),
+		Expected: nil,
+	},
+	{
+		Line:     1,
+		Input:    newStubBoletoRequestBB().WithTitle(models.Title{DocumentNumber: "loja"}).Build(),
+		Expected: nil,
+	},
+	{
+		Line:     2,
+		Input:    newStubBoletoRequestBB().WithTitle(models.Title{DocumentNumber: "123456"}).Build(),
+		Expected: nil,
+	},
+	{
+		Line:     3,
+		Input:    newStubBoletoRequestBB().WithTitle(models.Title{DocumentNumber: "lojas-15-digito"}).Build(),
+		Expected: nil,
+	},
+	{
+		Line:     4,
+		Input:    newStubBoletoRequestBB().WithTitle(models.Title{DocumentNumber: "lojas-16-digitos"}).Build(),
+		Expected: models.NewErrorResponse("MP400", "O campo documentNumber do título ultrapassou o limite permitido de 15 caracteres"),
+	},
+}
+
+func Test_GivenTheValidateTitleDocumentNumberMethodWasCalled_ThenItShouldCorrectlyValidateTheField(t *testing.T) {
+	for _, fact := range boletoRequestParameters {
+		boletoRequest := fact.Input.(*models.BoletoRequest)
+
+		result := bbValidateTitleDocumentNumber(boletoRequest)
+
+		assert.Equal(t, fact.Expected, result, fmt.Sprintf("bbValidateTitleDocumentNumber - Linha %d: Deve validar o campo documentNumber corretamente", fact.Line))
+	}
+}

--- a/test/test.go
+++ b/test/test.go
@@ -14,6 +14,7 @@ import (
 
 //Parameter Parâmetro de teste com input generico
 type Parameter struct {
+	Line     int
 	Input    interface{}
 	Expected interface{}
 	Length   int


### PR DESCRIPTION
# Descrição

### Tarefa [BPROC-463](https://mundipagg.atlassian.net/browse/BPROC-463) 

Esse PR tem o objetivo de enviar o campo __documentNumber__ para o __banco do Brasil__, complementando a [feature](https://github.com/mundipagg/OneV2/pull/587) implementada na aplicação __OneV2__.  

Pontos de alteração no PR
* envio do documentNumber ao banco do Brasil 
* tiramos a validação, que removia o que não fosse digito nesse campo, visto que na Doc do banco não obriga isso 
* adicionamos uma validação, para garantir que o length do campo documentNumber enviado esteja de acordo 

### Tipos de alterações

- [ ] Correção de bug 
- [x] Nova feature 
- [ ] Alteração ou remoção de funcionalidade existente
- [ ] Atualização de documentação

## Testes Locais

### Testes unitários / Integração caixa branca
![image](https://user-images.githubusercontent.com/36340027/175331125-352b1e3c-4bba-441b-971b-d45f32cc1136.png)

## Checklist

- [x] Associei corretamente a Tarefa do Board ao Pull Request.
- [x] Meu código segue as diretrizes desse projeto.
- [x] Eu revisei meu próprio código.
- [x] Eu comentei meu código em áreas particulares de difícil compreensão.
- [x] Eu atualizei a documentação de acordo com as mudanças realizadas.
- [x] Meu código não gerou novos warnings.
- [x] Eu adicionei testes que provam que minha correção é efetiva ou que a nova feature funciona.
- [x] Testes novos e existentes passam localmente com minhas alterações. 
- [x] Testes novos e existentes passam em staging com minhas alterações. 
- [x] Qualquer dependência dessa alteração já foi realizada (deploy, configuração em todos os ambientes, etc).
